### PR TITLE
Issue17: Fetch Manifest from URL

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -115,6 +115,46 @@ h4 {
     margin-top: 20px;
 }
 
+.manifest-loader {
+    max-width: 600px;
+    margin: 20px auto;
+    text-align: left;
+}
+
+.input-group {
+    display: flex;
+    margin-bottom: 10px;
+}
+
+.input-group input {
+    flex-grow: 1;
+    margin-right: 10px;
+    padding: 6px 10px;
+    font-size: 16px;
+    line-height: 1.5;
+}
+
+#manifestMessage {
+    margin-top: 10px;
+    font-weight: bold;
+}
+
+#loadManifest {
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    padding: 6px 20px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    margin: 0;
+    cursor: pointer;
+    line-height: 1.5;
+    text-transform: none;
+    vertical-align: middle;
+}
+
 body {
     font-family: Arial, Helvetica, sans-serif;
 }

--- a/web/tools.html
+++ b/web/tools.html
@@ -73,6 +73,14 @@
 
         <div id="tool_set">
             <h4>Tools</h4>
+            <div class="manifest-loader">
+                <h5>Load Manifest</h5>
+                <div class="input-group">
+                    <input type="text" id="manifestUrl" placeholder="Enter manifest URL">
+                    <button id="loadManifest" class="button">Next</button>
+                </div>
+                <div id="manifestMessage"></div>
+            </div>
         </div>
 
         <div id="footer-placeholder"></div>
@@ -94,6 +102,45 @@
                 document.getElementById('footer-placeholder').innerHTML = data;
             })
             .catch(error => console.error('Error loading footer:', error));
+        </script>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                const manifestUrl = document.getElementById('manifestUrl');
+                const loadManifest = document.getElementById('loadManifest');
+                const manifestMessage = document.getElementById('manifestMessage');
+
+                loadManifest.addEventListener('click', function() {
+                    const url = manifestUrl.value.trim();
+                    if (!url) {
+                        manifestMessage.textContent = 'Please enter a URL.';
+                        manifestMessage.style.color = 'red';
+                        return;
+                    }
+
+                    manifestMessage.textContent = 'Loading...';
+                    manifestMessage.style.color = 'black';
+
+                    fetch(url)
+                        .then(response => {
+                            if (!response.ok) {
+                                throw new Error('Network response was not ok');
+                            }
+                            return response.json();
+                        })
+                        .then(data => {
+                            // process JSON URL data
+                            manifestMessage.textContent = 'Manifest loaded successfully!';
+                            manifestMessage.style.color = 'green';
+                            console.log(data); // only logging the manifest for now. this can be changed to open a specific tool to use or however we want to handle the newly loaded manifest.
+                        })
+                        .catch(error => {
+                            manifestMessage.textContent = 'Failed to load manifest. Please check the URL and try again.';
+                            manifestMessage.style.color = 'red';
+                            console.error('Error:', error);
+                        });
+                });
+            });
         </script>
     </body>
 </html>

--- a/web/tools.html
+++ b/web/tools.html
@@ -71,16 +71,17 @@
             <h2>Tools Available in Rerum Playground</h2>
         </header>
 
+        <div class="manifest-loader">
+            <h5>Load Manifest</h5>
+            <div class="input-group">
+                <input type="text" id="manifestUrl" placeholder="Enter manifest URL">
+                <button id="loadManifest" class="button">Next</button>
+            </div>
+            <div id="manifestMessage"></div>
+        </div>
+        
         <div id="tool_set">
             <h4>Tools</h4>
-            <div class="manifest-loader">
-                <h5>Load Manifest</h5>
-                <div class="input-group">
-                    <input type="text" id="manifestUrl" placeholder="Enter manifest URL">
-                    <button id="loadManifest" class="button">Next</button>
-                </div>
-                <div id="manifestMessage"></div>
-            </div>
         </div>
 
         <div id="footer-placeholder"></div>


### PR DESCRIPTION
Fixes issue #17 

My Acceptance Criteria for this issue is:

- Users can input a URL pointing to a JSON manifest.
- The system validates the URL
- The system displays an appropriate message for success or failure.

In this PR, I have created a text field in the tools section of tools.html where users can input a URL pointing to a JSON manifest, and the system validates and displays the URL with an appropriate message for success or failure. 

I still need to extensively test the acceptance of URLs, as lots of unique JSON URLs will need to be viewable and fetchable via this text field. Below is an attachment of what my contributions look like in a browser.

![image](https://github.com/user-attachments/assets/88e4bf59-159a-4810-ac16-ef137c04c71d)
