### PR TITLE
Issue #18: Rerum Manifest Metadata Display

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -139,6 +139,15 @@ h4 {
     font-weight: bold;
 }
 
+.manifestInfo {
+    text-align: center;
+    background: #a3d1ff;
+}
+
+.manifestInfo p{
+    margin-bottom: 0px;
+}
+
 #loadManifest {
     background-color: #4CAF50;
     color: white;

--- a/web/tools.html
+++ b/web/tools.html
@@ -68,7 +68,14 @@
                     <img src="logo.png" alt="Rerum Playground">
                 </div>
             </div>
-            <div class="manifestInfo"></div>
+
+            <!--Fields for displaying metadata of loaded manifest-->
+            <div class="manifestInfo">
+                <p id="loadMessage"></p>
+                <div class="infoBar">
+                    <p id="manifestLabelField"></p>
+                </div>
+            </div>
 
             <h2>Tools Available in Rerum Playground</h2>
         </header>
@@ -122,7 +129,8 @@
                 const manifestUrl = document.getElementById('manifestUrl');
                 const loadManifest = document.getElementById('loadManifest');
                 const manifestMessage = document.getElementById('manifestMessage');
-                const manifestInfo = document.getElementById('manifestInfo');
+                const loadMessage = document.getElementById("loadMessage");
+                const manifestLabelField = document.getElementById("manifestLabelField");
 
                 loadManifest.addEventListener('click', function() {
                     const url = manifestUrl.value.trim();
@@ -149,13 +157,29 @@
 
                             storeManifestLink(url);
                             
-                            console.log(data); // only logging the manifest for now. this can be changed to open a specific tool to use or however we want to handle the newly loaded manifest.
+                            //console.log(data); only logging the manifest for now. this can be changed to open a specific tool to use or however we want to handle the newly loaded manifest.
                             
-                            //[Working on]: If manifest has the fields to be displayed, load text at the top of the page.
-                            /*
-                                manifestInfo.textContent = '';
-                                manifestInfo.style.color = 'black';
-                            */
+                            //If manifest has the fields to be displayed, load text at the top of the page.
+                            const loadedManifest = data;
+
+                            //Attempts to load specific fields from manifest. If any do not exist, displays error message. (Need to fix this to work a different way.)
+                            try{
+                                let manifestLabel = JSON.stringify(loadedManifest.label.en[0]);
+                                manifestLabel = "Name: " + manifestLabel.replaceAll("\"","");
+
+                                let manifestType = JSON.stringify(loadedManifest.type);
+                                manifestType = "Type: " + manifestType.replaceAll("\"","");
+
+                                let manifestItemCount = "Number of Items: " + loadedManifest.items.length;
+
+                                loadMessage.innerHTML = "<u>Current Object:</u>";
+                                //This should also be replaced with separate columns, in case there may be longer fields to display.
+                                manifestLabelField.innerHTML = manifestLabel + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + manifestType + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + manifestItemCount;
+                            }
+                            catch{
+                                loadMessage.innerHTML = "No metadata available!";
+                                manifestLabelField.innerHTML = "";
+                            }
                         })
                         .catch(error => {
                             manifestMessage.textContent = 'Failed to load manifest. Please check the URL and try again.';

--- a/web/tools.html
+++ b/web/tools.html
@@ -68,6 +68,8 @@
                     <img src="logo.png" alt="Rerum Playground">
                 </div>
             </div>
+            <div class="manifestInfo"></div>
+
             <h2>Tools Available in Rerum Playground</h2>
         </header>
 
@@ -114,6 +116,7 @@
                 const manifestUrl = document.getElementById('manifestUrl');
                 const loadManifest = document.getElementById('loadManifest');
                 const manifestMessage = document.getElementById('manifestMessage');
+                const manifestInfo = document.getElementById('manifestInfo');
 
                 loadManifest.addEventListener('click', function() {
                     const url = manifestUrl.value.trim();
@@ -138,6 +141,12 @@
                             manifestMessage.textContent = 'Manifest loaded successfully!';
                             manifestMessage.style.color = 'green';
                             console.log(data); // only logging the manifest for now. this can be changed to open a specific tool to use or however we want to handle the newly loaded manifest.
+                            
+                            //[Working on]: If manifest has the fields to be displayed, load text at the top of the page.
+                            /*
+                                manifestInfo.textContent = '';
+                                manifestInfo.style.color = 'black';
+                            */
                         })
                         .catch(error => {
                             manifestMessage.textContent = 'Failed to load manifest. Please check the URL and try again.';


### PR DESCRIPTION
Fixes Issue #18: Adds a basic display of key metadata from the currently loaded object manifest. Searches only for specific fields, displaying them on top of the page if they are found. If any are missing, an error message is displayed. Currently placed directly within the manifest loading function.