### PR TITLE
Manifest Loading Spinner

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -115,12 +115,6 @@ h4 {
     margin-top: 20px;
 }
 
-.manifest-loader {
-    max-width: 600px;
-    margin: 20px auto;
-    text-align: left;
-}
-
 .input-group {
     display: flex;
     margin-bottom: 10px;
@@ -149,7 +143,7 @@ h4 {
 }
 
 #loadManifest {
-    background-color: #4CAF50;
+    background-color: #7397f9;
     color: white;
     border: none;
     padding: 6px 20px;
@@ -288,7 +282,7 @@ footer::before{
     margin: 20px auto;
     text-align: left;
     position: relative;
-    min-height: 150px;
+    min-height: 100px;
 }
 
 .loading-overlay {

--- a/web/styles.css
+++ b/web/styles.css
@@ -268,3 +268,47 @@ footer::before{
     border: 1px solid #ccc;
     margin-top: 5px;
 }
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #3498db;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.manifest-loader {
+    max-width: 600px;
+    margin: 20px auto;
+    text-align: left;
+    position: relative;
+    min-height: 150px;
+}
+
+.loading-overlay {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.9);
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    z-index: 1000;
+    padding: 20px;
+}
+
+.loading-text {
+    margin-top: 10px;
+    font-weight: bold;
+    color: #3498db;
+    font-size: 16px;
+}

--- a/web/tools.html
+++ b/web/tools.html
@@ -84,7 +84,11 @@
             <h5>Load Manifest</h5>
             <div class="input-group">
                 <input type="text" id="manifestUrl" placeholder="Enter manifest URL">
-                <button id="loadManifest" class="button">Next</button>
+                <button id="loadManifest" class="button">Load</button>
+            </div>
+            <div class="loading-overlay">
+                <div class="spinner"></div>
+                <div class="loading-text">Loading Manifest...</div>
             </div>
             <div id="manifestMessage"></div>
         </div>
@@ -131,8 +135,18 @@
                 const manifestMessage = document.getElementById('manifestMessage');
                 const loadMessage = document.getElementById("loadMessage");
                 const manifestLabelField = document.getElementById("manifestLabelField");
+                const loadingOverlay = document.querySelector('.loading-overlay');
 
-                loadManifest.addEventListener('click', function() {
+                function showLoading() {
+                    loadingOverlay.style.display = 'flex';
+                    manifestMessage.textContent = '';
+                }
+
+                function hideLoading() {
+                    loadingOverlay.style.display = 'none';
+                }
+
+                loadManifest.addEventListener('click', async function() {
                     const url = manifestUrl.value.trim();
                     if (!url) {
                         manifestMessage.textContent = 'Please enter a URL.';
@@ -140,52 +154,47 @@
                         return;
                     }
 
-                    manifestMessage.textContent = 'Loading...';
-                    manifestMessage.style.color = 'black';
+                    showLoading();
 
-                    fetch(url)
-                        .then(response => {
-                            if (!response.ok) {
-                                throw new Error('Network response was not ok');
-                            }
-                            return response.json();
-                        })
-                        .then(data => {
-                            // process JSON URL data
-                            manifestMessage.textContent = 'Manifest loaded successfully!';
-                            manifestMessage.style.color = 'green';
+                    try {
+                        const response = await fetch(url);
+                        if (!response.ok) {
+                            throw new Error(`HTTP error! status: ${response.status}`);
+                        }
+                        const data = await response.json();
+            
+                        // Process the successfully loaded manifest
+                        hideLoading();
+                        manifestMessage.textContent = 'Manifest loaded successfully!';
+                        manifestMessage.style.color = 'green';
 
-                            storeManifestLink(url);
-                            
-                            //console.log(data); only logging the manifest for now. this can be changed to open a specific tool to use or however we want to handle the newly loaded manifest.
-                            
-                            //If manifest has the fields to be displayed, load text at the top of the page.
-                            const loadedManifest = data;
+                        storeManifestLink(url);
+            
+                        // Process manifest metadata
+                        try {
+                            let manifestLabel = JSON.stringify(data.label.en[0]);
+                            manifestLabel = "Name: " + manifestLabel.replaceAll("\"","");
 
-                            //Attempts to load specific fields from manifest. If any do not exist, displays error message. (Need to fix this to work a different way.)
-                            try{
-                                let manifestLabel = JSON.stringify(loadedManifest.label.en[0]);
-                                manifestLabel = "Name: " + manifestLabel.replaceAll("\"","");
+                            let manifestType = JSON.stringify(data.type);
+                            manifestType = "Type: " + manifestType.replaceAll("\"","");
 
-                                let manifestType = JSON.stringify(loadedManifest.type);
-                                manifestType = "Type: " + manifestType.replaceAll("\"","");
+                            let manifestItemCount = "Number of Items: " + data.items.length;
 
-                                let manifestItemCount = "Number of Items: " + loadedManifest.items.length;
-
-                                loadMessage.innerHTML = "<u>Current Object:</u>";
-                                //This should also be replaced with separate columns, in case there may be longer fields to display.
-                                manifestLabelField.innerHTML = manifestLabel + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + manifestType + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + manifestItemCount;
-                            }
-                            catch{
-                                loadMessage.innerHTML = "No metadata available!";
-                                manifestLabelField.innerHTML = "";
-                            }
-                        })
-                        .catch(error => {
-                            manifestMessage.textContent = 'Failed to load manifest. Please check the URL and try again.';
-                            manifestMessage.style.color = 'red';
-                            console.error('Error:', error);
-                        });
+                            loadMessage.innerHTML = "<u>Current Object:</u>";
+                            manifestLabelField.innerHTML = manifestLabel + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + 
+                                            manifestType + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + 
+                                            manifestItemCount;
+                        } catch (metadataError) {
+                            loadMessage.innerHTML = "No metadata available!";
+                            manifestLabelField.innerHTML = "";
+                        }
+                    //Manifest loaded unsuccessfully
+                    } catch (error) {
+                        hideLoading();
+                        manifestMessage.textContent = 'Failed to load manifest. Please check the URL and try again.';
+                        manifestMessage.style.color = 'red';
+                        console.error('Error:', error);
+                    }
                 });
             });
         </script>


### PR DESCRIPTION
Fixes issue #24 

I implemented a loading spinner that appears when the user is fetching a manifest from a URL.

I completed the following acceptance criteria:
- Display a loading spinner or message while the manifest is fetched from the URL.
- (1) The loading indicator should disappear once the manifest is successfully loaded.
- (2) If an error is encountered during fetching, the loading indicator should disappear and
- (2) an error message should be displayed. 

To test these changes, one must run the command "python -m http.server 8000" in the \web folder in the rerum-playground repo. This will launch a local server where the HTML code and its respective modules can be loaded. Then, in a browser, go to the link "http://localhost:8000/tools.html" to view/interact with the manifest load search query. 

Below are screenshots demonstrating the completed criteria. The numbers in parenthesis are associated with the same number in parenthesis listed at the start of the criteria bullet point.

*** To see the first bullet under the completed acceptance criteria, one must run the local server and load the manifest themselves. The manifest loader loads the manifest link faster than I can screenshot it.

(1) 
![image](https://github.com/user-attachments/assets/cc19d1e2-7881-417c-92b3-19372fed528d)

(2) 
![image](https://github.com/user-attachments/assets/bb3ca331-db8d-4c9f-866e-cb7ed07f99f5)


