### PR TITLE
Implement Recently Used Badge Logic for New Users

### DIFF
--- a/web/js/playground.js
+++ b/web/js/playground.js
@@ -11,6 +11,8 @@ import { storeManifestLink, getStoredManifestLinks } from './manifestStorage.js'
 
 const RECENTLY_USED_KEY = 'recentlyUsedTools';
 
+console.log("script is loading...");
+
 /**
  * Retrieve recently used tools from local storage.
  */
@@ -23,6 +25,7 @@ function getRecentlyUsedTools() {
  * Save recently used tools to local storage.
  */
 function saveRecentlyUsedTools(recentTools) {
+    console.log("Saving recent tools:", recentTools);
     localStorage.setItem(RECENTLY_USED_KEY, JSON.stringify(recentTools));
 }
 
@@ -30,17 +33,22 @@ function saveRecentlyUsedTools(recentTools) {
  * Update recently used tools, move the clicked tool to the top.
  */
 function updateRecentlyUsedTools(clickedTool) {
-    const recentTools = getRecentlyUsedTools();
-    const existingIndex = recentTools.findIndex(tool => tool.label.toLowerCase() === clickedTool.label.toLowerCase());
+    // const recentTools = getRecentlyUsedTools();
+    // const existingIndex = recentTools.findIndex(tool => tool.label.toLowerCase() === clickedTool.label.toLowerCase());
 
-    if (existingIndex !== -1) {
-        recentTools.splice(existingIndex, 1);
-    }
+    // if (existingIndex !== -1) {
+    //     recentTools.splice(existingIndex, 1);
+    // }
+    console.log("updateRecentlyUsedTools called with:", clickedTool);
+    let recentTools = getRecentlyUsedTools();
 
+    // Remove the tool if it exists in recentTools, then add it to the top
+    recentTools = recentTools.filter(tool => tool.label.toLowerCase() !== clickedTool.label.toLowerCase());
     recentTools.unshift(clickedTool);
 
     const topThreeTools = recentTools.slice(0, 3);
     saveRecentlyUsedTools(topThreeTools);
+    console.log("updated recent tools after click:", topThreeTools);
 }
 
 /**
@@ -83,8 +91,8 @@ function initializeTechnologies(config) {
  * Render tools, higlighting recently used ones.
  */
 function renderTools() {
+    console.log("renderTools is running");
     const toolSetContainer = document.getElementById('tool_set');
-
     if (!toolSetContainer) {
         console.error("Tool set container not found.");
         return;
@@ -93,18 +101,33 @@ function renderTools() {
     toolSetContainer.innerHTML = '';
 
     const recentTools = getRecentlyUsedTools();
+    const hasRecentlyUsedTools = recentTools.length > 0;
 
-    // Sort tools by their recent usage
-    const sortedTools = [...ToolsCatalog].sort((a, b) => {
-        const indexA = recentTools.findIndex(tool => tool.label.toLowerCase() === a.label.toLowerCase());
-        const indexB = recentTools.findIndex(tool => tool.label.toLowerCase() === b.label.toLowerCase());
-        return indexA === -1 ? 1 : indexB === -1 ? -1 : indexA - indexB;
-    });
+    // Divide ToolsCatalog into recently used tools and non-recently-used tools
+    const recentlyUsedLabels = recentTools.map(tool => tool.label.toLowerCase());
+    const recentToolsSet = new Set(recentlyUsedLabels);
+
+    const recentlyUsedTools = ToolsCatalog.filter(tool =>
+        recentToolsSet.has(tool.label.toLowerCase())
+    );
+
+    const nonRecentlyUsedTools = ToolsCatalog.filter(tool =>
+        !recentToolsSet.has(tool.label.toLowerCase())
+    );
+
+    // Sort recently used tools based on their order in recentTools array
+    const sortedRecentlyUsedTools = recentlyUsedTools.sort(
+        (a, b) =>
+            recentToolsSet.has(a.label.toLowerCase()) - recentToolsSet.has(b.label.toLowerCase())
+    );
+
+    // Combine sorted recently used tools and non-recently-used tools
+    const sortedTools = [...sortedRecentlyUsedTools, ...nonRecentlyUsedTools];
 
     const toolsWrapper = document.createElement('div');
 
     sortedTools.forEach((tool, index) => {
-        const isRecentlyUsed = index < 3 ? `<span class="recent-badge">Recently used</span>` : '';
+        const isRecentlyUsed = hasRecentlyUsedTools && index < 3 && recentToolsSet.has(tool.label.toLowerCase()) ? `<span class="recent-badge">Recently used</span>` : '';
         const toolHTML = `
             <a href="${tool.view}" target="_blank" class="catalogEntry">
                 <figure class="thumb">
@@ -129,6 +152,8 @@ function renderTools() {
             handleToolClick(toolLabel);
         });
     });
+
+    console.log("rendered tool order:", sortedTools.map(tool => tool.label));
 }
 
 /**
@@ -165,6 +190,7 @@ function renderStoredManifests() {
  * Handle tool click event to manage recently used logic and allow default navigation
  */
 function handleToolClick(toolLabel) {
+    console.log("handleToolClick called with:", toolLabel);
     const clickedTool = ToolsCatalog.find(tool => tool.label === toolLabel);
     if (clickedTool) {
         updateRecentlyUsedTools(clickedTool);

--- a/web/js/playground.js
+++ b/web/js/playground.js
@@ -11,6 +11,8 @@ import { storeManifestLink, getStoredManifestLinks } from './manifestStorage.js'
 
 const RECENTLY_USED_KEY = 'recentlyUsedTools';
 
+console.log("script is loading...");
+
 /**
  * Retrieve recently used tools from local storage.
  */
@@ -23,20 +25,30 @@ function getRecentlyUsedTools() {
  * Save recently used tools to local storage.
  */
 function saveRecentlyUsedTools(recentTools) {
+    console.log("Saving recent tools:", recentTools);
     localStorage.setItem(RECENTLY_USED_KEY, JSON.stringify(recentTools));
 }
 
 /**
  * Update recently used tools, move the clicked tool to the top.
  */
-function updateRecentlyUsedTools(clickedTool) {    
+function updateRecentlyUsedTools(clickedTool) {
+    // const recentTools = getRecentlyUsedTools();
+    // const existingIndex = recentTools.findIndex(tool => tool.label.toLowerCase() === clickedTool.label.toLowerCase());
+
+    // if (existingIndex !== -1) {
+    //     recentTools.splice(existingIndex, 1);
+    // }
+    console.log("updateRecentlyUsedTools called with:", clickedTool);
     let recentTools = getRecentlyUsedTools();
 
+    // Remove the tool if it exists in recentTools, then add it to the top
     recentTools = recentTools.filter(tool => tool.label.toLowerCase() !== clickedTool.label.toLowerCase());
     recentTools.unshift(clickedTool);
 
     const topThreeTools = recentTools.slice(0, 3);
     saveRecentlyUsedTools(topThreeTools);
+    console.log("updated recent tools after click:", topThreeTools);
 }
 
 /**
@@ -79,6 +91,7 @@ function initializeTechnologies(config) {
  * Render tools, higlighting recently used ones.
  */
 function renderTools() {
+    console.log("renderTools is running");
     const toolSetContainer = document.getElementById('tool_set');
     if (!toolSetContainer) {
         console.error("Tool set container not found.");
@@ -88,13 +101,33 @@ function renderTools() {
     toolSetContainer.innerHTML = '';
 
     const recentTools = getRecentlyUsedTools();
-    const recentToolLabels = new Set(recentTools.map(tool => tool.label.toLowerCase()));
+    const hasRecentlyUsedTools = recentTools.length > 0;
 
-    const sortedTools = [...recentTools, ...ToolsCatalog.filter(tool => !recentToolLabels.has(tool.label.toLowerCase()))];
+    // Divide ToolsCatalog into recently used tools and non-recently-used tools
+    const recentlyUsedLabels = recentTools.map(tool => tool.label.toLowerCase());
+    const recentToolsSet = new Set(recentlyUsedLabels);
+
+    const recentlyUsedTools = ToolsCatalog.filter(tool =>
+        recentToolsSet.has(tool.label.toLowerCase())
+    );
+
+    const nonRecentlyUsedTools = ToolsCatalog.filter(tool =>
+        !recentToolsSet.has(tool.label.toLowerCase())
+    );
+
+    // Sort recently used tools based on their order in recentTools array
+    const sortedRecentlyUsedTools = recentlyUsedTools.sort(
+        (a, b) =>
+            recentToolsSet.has(a.label.toLowerCase()) - recentToolsSet.has(b.label.toLowerCase())
+    );
+
+    // Combine sorted recently used tools and non-recently-used tools
+    const sortedTools = [...sortedRecentlyUsedTools, ...nonRecentlyUsedTools];
+
+    const toolsWrapper = document.createElement('div');
 
     sortedTools.forEach((tool, index) => {
-        const isRecentlyUsed = index < 3 ? `<span class="recent-badge">Recently used</span>` : '';;
-
+        const isRecentlyUsed = hasRecentlyUsedTools && index < 3 && recentToolsSet.has(tool.label.toLowerCase()) ? `<span class="recent-badge">Recently used</span>` : '';
         const toolHTML = `
             <a href="${tool.view}" target="_blank" class="catalogEntry">
                 <figure class="thumb">
@@ -105,18 +138,22 @@ function renderTools() {
                 </figure>
             </a>
         `;
-        toolSetContainer.innerHTML += toolHTML;
+        toolsWrapper.innerHTML += toolHTML;
     });
+
+    toolSetContainer.appendChild(toolsWrapper);
 
     // Add event listeners after elements are created
     const toolLinks = toolSetContainer.querySelectorAll('a.catalogEntry');
-    toolLinks.forEach((link, index) => {
+    toolLinks.forEach(link => {
         link.addEventListener('click', function (e) {
             e.preventDefault();
             const toolLabel = this.querySelector('label').innerText;
             handleToolClick(toolLabel);
         });
     });
+
+    console.log("rendered tool order:", sortedTools.map(tool => tool.label));
 }
 
 /**
@@ -153,6 +190,7 @@ function renderStoredManifests() {
  * Handle tool click event to manage recently used logic and allow default navigation
  */
 function handleToolClick(toolLabel) {
+    console.log("handleToolClick called with:", toolLabel);
     const clickedTool = ToolsCatalog.find(tool => tool.label === toolLabel);
     if (clickedTool) {
         updateRecentlyUsedTools(clickedTool);
@@ -164,15 +202,6 @@ function handleToolClick(toolLabel) {
         console.error('Clicked tool not found:', toolLabel);
     }
 }
-
-// Initialize and render tools on page load
-document.addEventListener('DOMContentLoaded', () => {
-    try {
-        renderTools();
-    } catch (err) {
-        console.error("Error initializing the playground:", err);
-    }
-});
 
 /**
  * Update tool order when a tool is clicked.


### PR DESCRIPTION
Fixes #34

- **What was changed:** Implemented the logic to label and sort the tools based on recent usage. Added checks to ensure only tools used by the user are labeled "Recently Used."

- **Why was it changed:** To ensure users see an accurate view of their tool interactions, enhancing usability by showing only the relevant recent tools.

- **How was it changed:**
Added sorting logic to move the most recently used tool to the top while maintaining non-recent tools in their default order.
Added conditions to display the "Recently Used" label only for the tools interacted with by the user.

**Known Issues**
The following issues remain and will be addressed separately:

1. **Sorting Behavior:** An attempt was made to update the sorting behavior so that the clicked tool moves to the first position, and all other tools shift one position to the right. However, inconsistencies remain, with the last recently used tool sometimes switching places with the newly clicked tool, causing unintended order.

An attempt was made to resolve the sorting behavior, but it will require further adjustments to function as intended.