### PR TITLE
Implement manifest loading with viewer links

### DIFF
--- a/web/tools.html
+++ b/web/tools.html
@@ -89,6 +89,13 @@
             <div id="manifestMessage"></div>
         </div>
 
+        <div class="viewer-links">
+            <h5>View Manifest in:</h5>
+            <div id="viewerLinks">
+                <!-- Links for Mirador and Universal Viewer will be dynamically added here -->
+            </div>
+        </div>
+
         <div class="dropdown">
             <label id="dropdownLabel" class="dropdown-label">Recently Used Links</label>
             <span id="dropdownArrow" class="dropdown-arrow">▼</span>


### PR DESCRIPTION
Fixes #20 
**Implements the following functionalities:**
- Adds the ability to load a manifest from a provided URL.
- Updates the list of recently used manifests, storing them in local storage.
- Displays links to view the manifest in Mirador and Universal Viewer.
- Dynamically renders the "Recently Used Links" dropdown with manifest URLs.
- Ensures a success message is displayed when the manifest is successfully loaded.

**What remains unresolved:**
- If the manifest does not contain images, a message should be displayed stating that no images are available for viewing.

**Next Steps:**
- Add functionality to detect if a manifest contains images.
- Display an appropriate message if no images are found in the manifest.