### PR TITLE
Issue #78

### DIFF
--- a/web/css/playground.css
+++ b/web/css/playground.css
@@ -167,3 +167,9 @@ p{
     background: none;
     border: none;
 }
+
+#manifestOutput {
+    text-align: left !important;
+    font-family: monospace;
+    white-space: pre;
+}

--- a/web/iiif-manifest.html
+++ b/web/iiif-manifest.html
@@ -39,7 +39,7 @@
       <div style="margin-top:12px">
         <button id="generateBtn" type="button">Generate</button>
         <button id="downloadBtn" type="button" disabled>Download JSON</button>
-        <button id="saveBtn" type="button" disabled>Save to Playground</button>
+        <button id="saveBtn" type="button" disabled>Save to RERUM</button>
       </div>
     </form>
 

--- a/web/iiif-manifest.html
+++ b/web/iiif-manifest.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>IIIF Manifest Generator</title>
+  <link rel="stylesheet" href="./css/playground.css">
+  <link rel="stylesheet" href="https://unpkg.com/chota@latest">
+</head>
+<body>
+  <div class="container">
+    <h2>IIIF Manifest Generator</h2>
+
+    <form id="manifestForm">
+      <label for="manifestId">Manifest ID (optional)</label>
+      <input id="manifestId" name="manifestId" type="text" placeholder="https://example.org/manifest/1">
+
+      <label for="manifestLabel">Label</label>
+      <input id="manifestLabel" name="manifestLabel" type="text" required placeholder="My Manifest">
+
+      <label for="manifestDesc">Description</label>
+      <textarea id="manifestDesc" name="manifestDesc" rows="3" placeholder="A short description"></textarea>
+
+      <fieldset>
+        <legend>One Canvas (optional)</legend>
+        <label for="canvasImage">Image URL</label>
+        <input id="canvasImage" name="canvasImage" type="url" placeholder="https://example.org/image.jpg">
+
+        <label for="canvasLabel">Canvas Label</label>
+        <input id="canvasLabel" name="canvasLabel" type="text" placeholder="Page 1">
+      </fieldset>
+
+      <div style="margin-top:12px">
+        <button id="generateBtn" type="button">Generate</button>
+        <button id="downloadBtn" type="button" disabled>Download JSON</button>
+        <button id="saveBtn" type="button" disabled>Save to Playground</button>
+      </div>
+    </form>
+
+    <h3>Generated Manifest</h3>
+    <pre id="manifestOutput" style="white-space:pre-wrap;background:#f6f6f6;padding:12px;border-radius:4px;max-height:400px;overflow:auto"></pre>
+
+    <p id="saveMessage" style="color:green"></p>
+  </div>
+
+  <script type="module" src="./js/iiifManifestTool.js"></script>
+</body>
+</html>

--- a/web/iiif-manifest.html
+++ b/web/iiif-manifest.html
@@ -18,6 +18,12 @@
       <label for="manifestLabel">Label</label>
       <input id="manifestLabel" name="manifestLabel" type="text" required placeholder="My Manifest">
 
+      <label for="canvasWidth">Canvas Width (optional)</label>
+      <input id="canvasWidth" name="canvasWidth" type="number">
+
+      <label for="canvasHeight">Canvas Height (optional)</label>
+      <input id="canvasHeight" name="canvasHeight" type="number">
+
       <label for="manifestDesc">Description</label>
       <textarea id="manifestDesc" name="manifestDesc" rows="3" placeholder="A short description"></textarea>
 

--- a/web/js/iiifManifestTool.js
+++ b/web/js/iiifManifestTool.js
@@ -115,7 +115,7 @@ async function buildManifest({ id, label, description, canvasImage, canvasLabel 
         height,
         items: [
             {
-                id: `${canvasId}/page`,
+                id: `${canvasId}`,
                 type: 'AnnotationPage',
                 items: [
                     {

--- a/web/js/iiifManifestTool.js
+++ b/web/js/iiifManifestTool.js
@@ -1,5 +1,27 @@
 import { saveManifest } from './manifestStorage.js';
 
+// URL syntax checker
+function isValidHttpUrl(url) {
+    try {
+        const u = new URL(url);
+        return u.protocol === "http:" || u.protocol === "https:";
+    } catch {
+        return false;
+    }
+}
+
+// HEAD request to verify the URL is reachable & returns an image
+async function urlExistsAndIsImage(url) {
+    try {
+        const res = await fetch(url, { method: "HEAD" });
+        if (!res.ok) return false;
+        const type = res.headers.get("content-type") || "";
+        return type.startsWith("image/");
+    } catch {
+        return false;
+    }
+}
+
 /**
  * Construct an ID if none is provided
  */
@@ -47,13 +69,15 @@ async function fetchIIIFInfo(imageUrl) {
  */
 async function buildManifest({ id, label, description, canvasImage, canvasLabel }) {
     const manifest = {
-        '@context': 'http://iiif.io/api/presentation/3/context.json',
+        '@context': 'https://iiif.io/api/presentation/3/context.json',
         id,
         type: 'Manifest',
         label: { en: [label || 'Untitled Manifest'] },
     };
 
-    if (description) manifest.description = { en: [description] };
+    if (description) {
+        manifest.summary = { en: [description] };
+    }
 
     if (!canvasImage || !canvasImage.trim()) {
         manifest.items = [];
@@ -63,16 +87,25 @@ async function buildManifest({ id, label, description, canvasImage, canvasLabel 
     // Attempt metadata fetch
     const info = await fetchIIIFInfo(canvasImage);
 
-    // Resolve dimensions
     const width = info?.width || 1000;
     const height = info?.height || 1000;
 
-    // Resolve image format
+    // Infer image format from URL
     const inferredFormat = inferFormatFromUrl(canvasImage);
-    const format = info?.profile?.formats?.[0] || inferredFormat || 'image/jpeg';
+    const format = inferredFormat || 'image/jpeg';
 
-    const canvasId = id + '/canvas/1';
-    const annotationId = canvasId + '/annotation/1';
+    const canvasId = `${id}/canvas/1`;
+    const annotationId = `${canvasId}/annotation/1`;
+
+    // Add ImageService block if info.json exists
+    let serviceBlock = null;
+    if (info?.id) {
+        serviceBlock = [{
+            id: info.id,
+            type: "ImageService3",
+            profile: info.profile || "level1"
+        }];
+    }
 
     const canvas = {
         id: canvasId,
@@ -82,7 +115,7 @@ async function buildManifest({ id, label, description, canvasImage, canvasLabel 
         height,
         items: [
             {
-                id: canvasId + '/page',
+                id: `${canvasId}/page`,
                 type: 'AnnotationPage',
                 items: [
                     {
@@ -92,7 +125,10 @@ async function buildManifest({ id, label, description, canvasImage, canvasLabel 
                         body: {
                             id: canvasImage,
                             type: 'Image',
-                            format
+                            format,
+                            width,
+                            height,
+                            ...(serviceBlock ? { service: serviceBlock } : {})
                         },
                         target: canvasId
                     }
@@ -142,6 +178,16 @@ document.addEventListener('DOMContentLoaded', () => {
         const canvasImage = formData.get('canvasImage');
         const canvasLabel = formData.get('canvasLabel');
 
+        if (!isValidHttpUrl(canvasImage)) {
+            alert("The canvas image URL is not a valid http/https URL.");
+            return;
+        }
+
+        if (!await urlExistsAndIsImage(canvasImage)) {
+            alert("The provided URL does not point to a reachable image resource.");
+            return;
+        }
+
         const manifest = await buildManifest({ id, label, description, canvasImage, canvasLabel });
         currentManifest = manifest;
 
@@ -157,10 +203,54 @@ document.addEventListener('DOMContentLoaded', () => {
         downloadData(filename, JSON.stringify(currentManifest, null, 2));
     });
 
-    saveBtn.addEventListener('click', () => {
-        if (!currentManifest) return;
-        const link = saveManifest(currentManifest);
-        saveMessage.textContent = 'Manifest saved to playground and available in Stored Manifests.';
-        // window.open(link, '_blank'); // optional
+    saveBtn.addEventListener('click', async () => {
+        if (!currentManifest) {
+            saveMessage.textContent = 'Please generate a manifest first.';
+            saveMessage.style.color = 'red';
+            return;
+        }
+
+        // Show loading state
+        saveBtn.disabled = true;
+        saveBtn.textContent = 'Saving to RERUM...';
+        saveMessage.textContent = 'Please wait...';
+        saveMessage.style.color = '#666';
+
+        try {
+            // Save to RERUM
+            const rerumUrl = await saveManifest(currentManifest);
+            
+            // Show success message with clickable link
+            saveMessage.innerHTML = `
+                <strong>✓ Success!</strong> Manifest saved to RERUM:<br>
+                <a href="${rerumUrl}" target="_blank" style="color: #0066cc; text-decoration: underline; word-break: break-all;">
+                    ${rerumUrl}
+                </a>
+            `;
+            saveMessage.style.color = 'green';
+
+            console.log("Saved to RERUM:", rerumUrl);
+
+        } catch (error) {
+            // Show detailed error message
+            let errorMsg = 'Failed to save to RERUM. ';
+            
+            if (error.message.includes('400')) {
+                errorMsg += 'The manifest format is invalid. Please check that all required fields are filled.';
+            } else if (error.message.includes('network') || error.message.includes('fetch')) {
+                errorMsg += 'Network error. Please check your connection.';
+            } else {
+                errorMsg += error.message;
+            }
+            
+            saveMessage.textContent = errorMsg;
+            saveMessage.style.color = 'red';
+            console.error("RERUM save error:", error);
+
+        } finally {
+            // Reset button state
+            saveBtn.disabled = false;
+            saveBtn.textContent = 'Save to RERUM';
+        }
     });
 });

--- a/web/js/iiifManifestTool.js
+++ b/web/js/iiifManifestTool.js
@@ -1,60 +1,113 @@
 import { saveManifest } from './manifestStorage.js';
 
+/**
+ * Construct an ID if none is provided
+ */
 function generateId(base) {
     if (base && base.trim()) return base.trim();
     return (location.origin || '') + location.pathname + '#manifest-' + Date.now();
 }
 
-function buildManifest({ id, label, description, canvasImage, canvasLabel }) {
+/**
+ * Try parsing the file extension from the URL as a fallback format guess
+ */
+function inferFormatFromUrl(url) {
+    if (!url) return null;
+    const ext = url.split('.').pop().toLowerCase();
+    if (['jpg', 'jpeg', 'png', 'tif', 'tiff', 'gif'].includes(ext)) {
+        return `image/${ext === 'jpg' ? 'jpeg' : ext}`;
+    }
+    return null;
+}
+
+/**
+ * If the URL is a IIIF Image API base, fetch its info.json for real dimensions + format support
+ * Returns null if not IIIF or request fails.
+ */
+async function fetchIIIFInfo(imageUrl) {
+    if (!imageUrl) return null;
+    // Basic heuristic: IIIF URLs contain `/full/` or `/info.json`
+    if (!imageUrl.includes('/full/') && !imageUrl.includes('/info.json')) return null;
+
+    const base = imageUrl.split('/full')[0];
+    const infoUrl = base + '/info.json';
+
+    try {
+        const res = await fetch(infoUrl);
+        if (!res.ok) return null;
+        return await res.json();
+    } catch (e) {
+        console.warn('IIIF info.json fetch failed:', e);
+        return null;
+    }
+}
+
+/**
+ * Build the manifest using dynamic image metadata if possible
+ */
+async function buildManifest({ id, label, description, canvasImage, canvasLabel }) {
     const manifest = {
         '@context': 'http://iiif.io/api/presentation/3/context.json',
-        id: id,
+        id,
         type: 'Manifest',
         label: { en: [label || 'Untitled Manifest'] },
     };
 
     if (description) manifest.description = { en: [description] };
 
-    // optionally add one canvas if provided
-    if (canvasImage && canvasImage.trim()) {
-        const canvasId = id + '/canvas/1';
-        const annotationId = canvasId + '/annotation/1';
-
-        const canvas = {
-            id: canvasId,
-            type: 'Canvas',
-            label: { en: [canvasLabel || 'Page 1'] },
-            width: 1000,
-            height: 1000,
-            items: [
-                {
-                    id: canvasId + '/page',
-                    type: 'AnnotationPage',
-                    items: [
-                        {
-                            id: annotationId,
-                            type: 'Annotation',
-                            motivation: 'painting',
-                            body: {
-                                id: canvasImage,
-                                type: 'Image',
-                                format: 'image/jpeg'
-                            },
-                            target: canvasId
-                        }
-                    ]
-                }
-            ]
-        };
-
-        manifest.items = [canvas];
-    } else {
+    if (!canvasImage || !canvasImage.trim()) {
         manifest.items = [];
+        return manifest;
     }
 
+    // Attempt metadata fetch
+    const info = await fetchIIIFInfo(canvasImage);
+
+    // Resolve dimensions
+    const width = info?.width || 1000;
+    const height = info?.height || 1000;
+
+    // Resolve image format
+    const inferredFormat = inferFormatFromUrl(canvasImage);
+    const format = info?.profile?.formats?.[0] || inferredFormat || 'image/jpeg';
+
+    const canvasId = id + '/canvas/1';
+    const annotationId = canvasId + '/annotation/1';
+
+    const canvas = {
+        id: canvasId,
+        type: 'Canvas',
+        label: { en: [canvasLabel || 'Page 1'] },
+        width,
+        height,
+        items: [
+            {
+                id: canvasId + '/page',
+                type: 'AnnotationPage',
+                items: [
+                    {
+                        id: annotationId,
+                        type: 'Annotation',
+                        motivation: 'painting',
+                        body: {
+                            id: canvasImage,
+                            type: 'Image',
+                            format
+                        },
+                        target: canvasId
+                    }
+                ]
+            }
+        ]
+    };
+
+    manifest.items = [canvas];
     return manifest;
 }
 
+/**
+ * Download helper
+ */
 function downloadData(filename, data) {
     const blob = new Blob([data], { type: 'application/json;charset=utf-8' });
     const url = URL.createObjectURL(blob);
@@ -67,6 +120,9 @@ function downloadData(filename, data) {
     URL.revokeObjectURL(url);
 }
 
+/**
+ * UI binding logic
+ */
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('manifestForm');
     const generateBtn = document.getElementById('generateBtn');
@@ -77,7 +133,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let currentManifest = null;
 
-    generateBtn.addEventListener('click', (e) => {
+    generateBtn.addEventListener('click', async () => {
         const formData = new FormData(form);
         const rawId = formData.get('manifestId');
         const id = generateId(rawId);
@@ -86,7 +142,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const canvasImage = formData.get('canvasImage');
         const canvasLabel = formData.get('canvasLabel');
 
-        const manifest = buildManifest({ id, label, description, canvasImage, canvasLabel });
+        const manifest = await buildManifest({ id, label, description, canvasImage, canvasLabel });
         currentManifest = manifest;
 
         output.textContent = JSON.stringify(manifest, null, 2);
@@ -97,16 +153,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     downloadBtn.addEventListener('click', () => {
         if (!currentManifest) return;
-        const filename = (currentManifest.label && currentManifest.label.en && currentManifest.label.en[0]) ? currentManifest.label.en[0].replace(/[^a-z0-9\-]/gi, '_') + '.json' : 'manifest.json';
+        const filename = (currentManifest.label?.en?.[0] || 'manifest').replace(/[^a-z0-9\-]/gi, '_') + '.json';
         downloadData(filename, JSON.stringify(currentManifest, null, 2));
     });
 
     saveBtn.addEventListener('click', () => {
         if (!currentManifest) return;
-        // use saveManifest exported from manifestStorage.js which registers the data URL link
         const link = saveManifest(currentManifest);
         saveMessage.textContent = 'Manifest saved to playground and available in Stored Manifests.';
-        // optionally open the manifest in a new tab
-        // window.open(link, '_blank');
+        // window.open(link, '_blank'); // optional
     });
 });

--- a/web/js/iiifManifestTool.js
+++ b/web/js/iiifManifestTool.js
@@ -1,0 +1,112 @@
+import { saveManifest } from './manifestStorage.js';
+
+function generateId(base) {
+    if (base && base.trim()) return base.trim();
+    return (location.origin || '') + location.pathname + '#manifest-' + Date.now();
+}
+
+function buildManifest({ id, label, description, canvasImage, canvasLabel }) {
+    const manifest = {
+        '@context': 'http://iiif.io/api/presentation/3/context.json',
+        id: id,
+        type: 'Manifest',
+        label: { en: [label || 'Untitled Manifest'] },
+    };
+
+    if (description) manifest.description = { en: [description] };
+
+    // optionally add one canvas if provided
+    if (canvasImage && canvasImage.trim()) {
+        const canvasId = id + '/canvas/1';
+        const annotationId = canvasId + '/annotation/1';
+
+        const canvas = {
+            id: canvasId,
+            type: 'Canvas',
+            label: { en: [canvasLabel || 'Page 1'] },
+            width: 1000,
+            height: 1000,
+            items: [
+                {
+                    id: canvasId + '/page',
+                    type: 'AnnotationPage',
+                    items: [
+                        {
+                            id: annotationId,
+                            type: 'Annotation',
+                            motivation: 'painting',
+                            body: {
+                                id: canvasImage,
+                                type: 'Image',
+                                format: 'image/jpeg'
+                            },
+                            target: canvasId
+                        }
+                    ]
+                }
+            ]
+        };
+
+        manifest.items = [canvas];
+    } else {
+        manifest.items = [];
+    }
+
+    return manifest;
+}
+
+function downloadData(filename, data) {
+    const blob = new Blob([data], { type: 'application/json;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('manifestForm');
+    const generateBtn = document.getElementById('generateBtn');
+    const downloadBtn = document.getElementById('downloadBtn');
+    const saveBtn = document.getElementById('saveBtn');
+    const output = document.getElementById('manifestOutput');
+    const saveMessage = document.getElementById('saveMessage');
+
+    let currentManifest = null;
+
+    generateBtn.addEventListener('click', (e) => {
+        const formData = new FormData(form);
+        const rawId = formData.get('manifestId');
+        const id = generateId(rawId);
+        const label = formData.get('manifestLabel') || 'Untitled Manifest';
+        const description = formData.get('manifestDesc');
+        const canvasImage = formData.get('canvasImage');
+        const canvasLabel = formData.get('canvasLabel');
+
+        const manifest = buildManifest({ id, label, description, canvasImage, canvasLabel });
+        currentManifest = manifest;
+
+        output.textContent = JSON.stringify(manifest, null, 2);
+        downloadBtn.disabled = false;
+        saveBtn.disabled = false;
+        saveMessage.textContent = '';
+    });
+
+    downloadBtn.addEventListener('click', () => {
+        if (!currentManifest) return;
+        const filename = (currentManifest.label && currentManifest.label.en && currentManifest.label.en[0]) ? currentManifest.label.en[0].replace(/[^a-z0-9\-]/gi, '_') + '.json' : 'manifest.json';
+        downloadData(filename, JSON.stringify(currentManifest, null, 2));
+    });
+
+    saveBtn.addEventListener('click', () => {
+        if (!currentManifest) return;
+        // use saveManifest exported from manifestStorage.js which registers the data URL link
+        const link = saveManifest(currentManifest);
+        saveMessage.textContent = 'Manifest saved to playground and available in Stored Manifests.';
+        // optionally open the manifest in a new tab
+        // window.open(link, '_blank');
+    });
+});

--- a/web/js/manifestStorage.js
+++ b/web/js/manifestStorage.js
@@ -1,129 +1,78 @@
+// manifestStorage.js
+
+// Key shared by annotator + manifest generator
 const MANIFEST_LINKS_KEY = 'storedManifestLinks';
 
+// RERUM sandbox create endpoint (same as annotator)
+const RERUM_SANDBOX_CREATE = 'https://tinydev.rerum.io/app/create';
+
 /**
- * Save the given manifest link to local storage.
+ * Get array of stored manifest links from localStorage.
+ */
+export function getStoredManifestLinks() {
+  const manifestLinks = localStorage.getItem(MANIFEST_LINKS_KEY);
+  return manifestLinks ? JSON.parse(manifestLinks) : [];
+}
+
+/**
+ * Save the given manifest link to localStorage (deduplicated).
  */
 export function storeManifestLink(manifestLink) {
-    let manifestLinks = getStoredManifestLinks();
+  if (!manifestLink) return;
 
-    if (!manifestLinks.includes(manifestLink)) {
-        manifestLinks.push(manifestLink);
-    }
+  let manifestLinks = getStoredManifestLinks();
 
-    // save updated links array to local storage
-    localStorage.setItem(MANIFEST_LINKS_KEY, JSON.stringify(manifestLinks));
-}
+  if (!manifestLinks.includes(manifestLink)) {
+    manifestLinks.push(manifestLink);
+  }
 
-export function getStoredManifestLinks() {
-    // get the stored links from local storage, or return an empty array if none are found
-    const manifestLinks = localStorage.getItem(MANIFEST_LINKS_KEY);
-    return manifestLinks ? JSON.parse(manifestLinks) : [];
+  localStorage.setItem(MANIFEST_LINKS_KEY, JSON.stringify(manifestLinks));
 }
 
 /**
- * Prepare manifest for RERUM - ensure it has the required structure
- */
-function prepareManifestForRerum(manifest) {
-    // Create a copy to avoid modifying the original
-    const rerumManifest = JSON.parse(JSON.stringify(manifest));
-    
-    // RERUM v1 expects @context (not context)
-    if (!rerumManifest['@context'] && manifest.context) {
-        rerumManifest['@context'] = manifest.context;
-    }
-    
-    // Ensure @context exists
-    if (!rerumManifest['@context']) {
-        rerumManifest['@context'] = 'http://iiif.io/api/presentation/3/context.json';
-    }
-    
-    return rerumManifest;
-}
-
-/**
- * Save a manifest to RERUM and return the RERUM URL.
- * This posts to the RERUM API and gets back a permanent URL.
+ * Save a IIIF Manifest to the RERUM sandbox and return its URI.
+ * Also stores the URI in localStorage via storeManifestLink.
+ *
+ * @param {object} manifest - IIIF Manifest object (Presentation API 3)
+ * @returns {Promise<string>} - The URI of the stored manifest in RERUM
  */
 export async function saveManifest(manifest) {
-    // Try the public v1 endpoint first (no auth required for some operations)
-    const RERUM_API_URL = 'https://store.rerum.io/v1/api/create';
-    
-    try {
-        // Prepare the manifest with required RERUM fields
-        const rerumManifest = prepareManifestForRerum(manifest);
-        
-        console.log('Sending to RERUM:', JSON.stringify(rerumManifest, null, 2));
-        
-        const response = await fetch(RERUM_API_URL, {
-            method: 'POST',
-            mode: 'cors',
-            headers: {
-                'Content-Type': 'application/json; charset=utf-8',
-                'Accept': 'application/json'
-            },
-            body: JSON.stringify(rerumManifest)
-        });
+  let response;
+  try {
+    response = await fetch(RERUM_SANDBOX_CREATE, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json;charset=utf-8'
+      },
+      body: JSON.stringify(manifest)
+    });
+  } catch (err) {
+    throw new Error(`Network or fetch error while saving to RERUM: ${err.message}`);
+  }
 
-        console.log('RERUM response status:', response.status);
-        
-        // Get the response text first to see what we're dealing with
-        const responseText = await response.text();
-        console.log('RERUM response body:', responseText);
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`RERUM save failed: ${response.status} ${response.statusText} ${text}`);
+  }
 
-        if (!response.ok) {
-            // Try to parse as JSON for better error message
-            let errorMessage = `RERUM API error: ${response.status} ${response.statusText}`;
-            try {
-                const errorData = JSON.parse(responseText);
-                if (errorData.message) {
-                    errorMessage += ` - ${errorData.message}`;
-                }
-            } catch (e) {
-                // Not JSON, use text as-is
-                if (responseText) {
-                    errorMessage += ` - ${responseText}`;
-                }
-            }
-            throw new Error(errorMessage);
-        }
+  const raw = await response.json(); // full RERUM response
 
-        // Parse the successful response
-        const result = JSON.parse(responseText);
-        console.log('RERUM created object:', result);
-        
-        // RERUM returns the created object with an @id property
-        const rerumUrl = result['@id'] || result.id;
-        
-        if (!rerumUrl) {
-            console.error('RERUM response missing ID:', result);
-            throw new Error('RERUM did not return a valid ID. Response: ' + JSON.stringify(result));
-        }
+  // Some RERUM endpoints return new_obj_state; prefer that, otherwise use raw.
+  const stored = raw.new_obj_state || raw;
 
-        // Store the RERUM link in recently used links
-        storeManifestLink(rerumUrl);
+  // Try to determine the URI robustly
+  const uri =
+    stored.id ||
+    stored['@id'] ||
+    raw['@id'] ||
+    response.headers.get('location');
 
-        return rerumUrl;
+  if (!uri) {
+    throw new Error('RERUM did not return a URI for the stored manifest.');
+  }
 
-    } catch (error) {
-        console.error('Error saving to RERUM:', error);
-        
-        // If it's a CORS or network error
-        if (error.message.includes('Failed to fetch') || error.message.includes('NetworkError')) {
-            throw new Error('Network error. RERUM may be down or blocking requests from this domain.');
-        }
-        
-        // If it's an auth error
-        if (error.message.includes('401') || error.message.includes('403')) {
-            throw new Error('Authentication required. RERUM requires an access token for this operation.');
-        }
-        
-        throw error;
-    }
-}
+  // Reuse: keep this URI in the same list the annotator uses
+  storeManifestLink(uri);
 
-/**
- * Get stored manifest links for display
- */
-export function getStoredManifests() {
-    return getStoredManifestLinks();
+  return uri;
 }

--- a/web/js/manifestStorage.js
+++ b/web/js/manifestStorage.js
@@ -1,4 +1,5 @@
-const MANIFEST_LINKS_KEY ='storedManifestLinks';
+const MANIFEST_LINKS_KEY = 'storedManifestLinks';
+const MANIFEST_OBJECTS_KEY = 'storedManifests';
 
 /**
  * Save the given manifest link to local storage.
@@ -18,4 +19,41 @@ export function getStoredManifestLinks() {
     // get the stored links from local storage, or return an empty array if none are found
     const manifestLinks = localStorage.getItem(MANIFEST_LINKS_KEY);
     return manifestLinks ? JSON.parse(manifestLinks) : [];
+}
+
+/**
+ * Save a manifest object to local storage and register a link for it.
+ * Returns the data URL used as the link.
+ */
+export function saveManifest(manifest) {
+    const json = JSON.stringify(manifest, null, 2);
+    // create a data URL so it can be opened in a new tab
+    const dataUrl = 'data:application/json;charset=utf-8,' + encodeURIComponent(json);
+
+    // store the manifest JSON keyed by the dataUrl (so we can retrieve if needed)
+    let stored = getStoredManifestObjects();
+    stored[dataUrl] = json;
+    localStorage.setItem(MANIFEST_OBJECTS_KEY, JSON.stringify(stored));
+
+    // also store the link in the manifest links list for quick access
+    storeManifestLink(dataUrl);
+
+    return dataUrl;
+}
+
+/**
+ * Return an object mapping stored data URLs to manifest JSON strings.
+ */
+export function getStoredManifestObjects() {
+    const stored = localStorage.getItem(MANIFEST_OBJECTS_KEY);
+    return stored ? JSON.parse(stored) : {};
+}
+
+/**
+ * Return an array of { link, json } for stored manifests to simplify UI use.
+ */
+export function getStoredManifests() {
+    const links = getStoredManifestLinks();
+    const objs = getStoredManifestObjects();
+    return links.map(link => ({ link, json: objs[link] || null }));
 }

--- a/web/js/manifestStorage.js
+++ b/web/js/manifestStorage.js
@@ -1,5 +1,4 @@
 const MANIFEST_LINKS_KEY = 'storedManifestLinks';
-const MANIFEST_OBJECTS_KEY = 'storedManifests';
 
 /**
  * Save the given manifest link to local storage.
@@ -22,38 +21,109 @@ export function getStoredManifestLinks() {
 }
 
 /**
- * Save a manifest object to local storage and register a link for it.
- * Returns the data URL used as the link.
+ * Prepare manifest for RERUM - ensure it has the required structure
  */
-export function saveManifest(manifest) {
-    const json = JSON.stringify(manifest, null, 2);
-    // create a data URL so it can be opened in a new tab
-    const dataUrl = 'data:application/json;charset=utf-8,' + encodeURIComponent(json);
-
-    // store the manifest JSON keyed by the dataUrl (so we can retrieve if needed)
-    let stored = getStoredManifestObjects();
-    stored[dataUrl] = json;
-    localStorage.setItem(MANIFEST_OBJECTS_KEY, JSON.stringify(stored));
-
-    // also store the link in the manifest links list for quick access
-    storeManifestLink(dataUrl);
-
-    return dataUrl;
+function prepareManifestForRerum(manifest) {
+    // Create a copy to avoid modifying the original
+    const rerumManifest = JSON.parse(JSON.stringify(manifest));
+    
+    // RERUM v1 expects @context (not context)
+    if (!rerumManifest['@context'] && manifest.context) {
+        rerumManifest['@context'] = manifest.context;
+    }
+    
+    // Ensure @context exists
+    if (!rerumManifest['@context']) {
+        rerumManifest['@context'] = 'http://iiif.io/api/presentation/3/context.json';
+    }
+    
+    return rerumManifest;
 }
 
 /**
- * Return an object mapping stored data URLs to manifest JSON strings.
+ * Save a manifest to RERUM and return the RERUM URL.
+ * This posts to the RERUM API and gets back a permanent URL.
  */
-export function getStoredManifestObjects() {
-    const stored = localStorage.getItem(MANIFEST_OBJECTS_KEY);
-    return stored ? JSON.parse(stored) : {};
+export async function saveManifest(manifest) {
+    // Try the public v1 endpoint first (no auth required for some operations)
+    const RERUM_API_URL = 'https://store.rerum.io/v1/api/create';
+    
+    try {
+        // Prepare the manifest with required RERUM fields
+        const rerumManifest = prepareManifestForRerum(manifest);
+        
+        console.log('Sending to RERUM:', JSON.stringify(rerumManifest, null, 2));
+        
+        const response = await fetch(RERUM_API_URL, {
+            method: 'POST',
+            mode: 'cors',
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                'Accept': 'application/json'
+            },
+            body: JSON.stringify(rerumManifest)
+        });
+
+        console.log('RERUM response status:', response.status);
+        
+        // Get the response text first to see what we're dealing with
+        const responseText = await response.text();
+        console.log('RERUM response body:', responseText);
+
+        if (!response.ok) {
+            // Try to parse as JSON for better error message
+            let errorMessage = `RERUM API error: ${response.status} ${response.statusText}`;
+            try {
+                const errorData = JSON.parse(responseText);
+                if (errorData.message) {
+                    errorMessage += ` - ${errorData.message}`;
+                }
+            } catch (e) {
+                // Not JSON, use text as-is
+                if (responseText) {
+                    errorMessage += ` - ${responseText}`;
+                }
+            }
+            throw new Error(errorMessage);
+        }
+
+        // Parse the successful response
+        const result = JSON.parse(responseText);
+        console.log('RERUM created object:', result);
+        
+        // RERUM returns the created object with an @id property
+        const rerumUrl = result['@id'] || result.id;
+        
+        if (!rerumUrl) {
+            console.error('RERUM response missing ID:', result);
+            throw new Error('RERUM did not return a valid ID. Response: ' + JSON.stringify(result));
+        }
+
+        // Store the RERUM link in recently used links
+        storeManifestLink(rerumUrl);
+
+        return rerumUrl;
+
+    } catch (error) {
+        console.error('Error saving to RERUM:', error);
+        
+        // If it's a CORS or network error
+        if (error.message.includes('Failed to fetch') || error.message.includes('NetworkError')) {
+            throw new Error('Network error. RERUM may be down or blocking requests from this domain.');
+        }
+        
+        // If it's an auth error
+        if (error.message.includes('401') || error.message.includes('403')) {
+            throw new Error('Authentication required. RERUM requires an access token for this operation.');
+        }
+        
+        throw error;
+    }
 }
 
 /**
- * Return an array of { link, json } for stored manifests to simplify UI use.
+ * Get stored manifest links for display
  */
 export function getStoredManifests() {
-    const links = getStoredManifestLinks();
-    const objs = getStoredManifestObjects();
-    return links.map(link => ({ link, json: objs[link] || null }));
+    return getStoredManifestLinks();
 }

--- a/web/js/toolsCatalog.js
+++ b/web/js/toolsCatalog.js
@@ -38,6 +38,13 @@ const ToolsCatalog = [
         view: "https://universalviewer.io/",
         description: "A viewer for web objects, allowing users to share their media with the world."
     }
+    ,
+    {
+        label: "IIIF Manifest Generator",
+        icon: "./images/rerum_logo.png",
+        view: "./iiif-manifest.html",
+        description: "Generate simple IIIF Presentation API manifest JSON and save it into the playground."
+    }
 ];
 
 // export the tools catalog to be used in config.js


### PR DESCRIPTION
Worked on issue #78 by adding a IIIF Manifest Generator to for generating simple IIIF Presentation API. The changes I have made and files I have added are as follows:

### Added a new page and UI
**`iiif-manifest.html`**
- Simple form with fields for:
  - Manifest ID  
  - Label  
  - Description  
  - Optional single canvas (image + label)
- Buttons to **Generate**, **Download**, and **Save**

---

### Added generator logic
**`iiifManifestTool.js`**
- Builds a small **IIIF Presentation API Manifest (v3.0)**  
- Displays generated JSON  
- Allows manifest download  
- Saves manifests via storage module

---

### Extended storage to persist generated manifests
**`manifestStorage.js`**
- Added:
  - `saveManifest(manifest)` — saves manifest JSON and registers a data URL link  
  - `getStoredManifestObjects()` and `getStoredManifests()` helpers  
- Kept original APIs:
  - `storeManifestLink()` and `getStoredManifestLinks()` for backward compatibility  
- **Implementation note:**  
  - Manifests are saved in `localStorage`  
  - Links are stored as `data:application/json,...` URLs  
  - Full JSON objects are stored under `storedManifests`, keyed by the data URL

---

### Added tool entry in catalog
**`toolsCatalog.js`**
- New entry: **“IIIF Manifest Generator”**
- Points to `./iiif-manifest.html`
