### PR TITLE
115 implement annotation search logic

### DIFF
--- a/web/js/config.js
+++ b/web/js/config.js
@@ -16,6 +16,7 @@ export default {
         SINCE: "http://devstore.rerum.io/v1/since",
         HISTORY: "http://devstore.rerum.io/v1/history",
         SEARCH_TEXT: "https://devstore.rerum.io/v1/api/search/text",
+        SEARCH_TEXT_FALLBACK: "https://devstore.rerum.io/v1/api/search",
         SEARCH_PHRASE: "https://devstore.rerum.io/v1/api/search/phrase"
     },
     /** Max page size for RERUM search (API recommends ≤ 100). */

--- a/web/js/config.js
+++ b/web/js/config.js
@@ -14,8 +14,16 @@ export default {
         OVERWRITE: "http://tinydev.rerum.io/app/overwrite",
         QUERY: "http://tinydev.rerum.io/app/query",
         SINCE: "http://devstore.rerum.io/v1/since",
-        HISTORY: "http://devstore.rerum.io/v1/history"
+        HISTORY: "http://devstore.rerum.io/v1/history",
+        SEARCH_TEXT: "https://devstore.rerum.io/v1/api/search/text",
+        SEARCH_PHRASE: "https://devstore.rerum.io/v1/api/search/phrase"
     },
+    /** Max page size for RERUM search (API recommends ≤ 100). */
+    SEARCH_PAGE_LIMIT: 100,
+    /** Prevent burst submissions from repeatedly hammering search endpoints. */
+    SEARCH_COOLDOWN_MS: 500,
+    /** Cache repeated identical queries briefly to reduce expensive duplicate calls. */
+    SEARCH_CACHE_TTL_MS: 60_000,
     EVENTS: {
         CREATED: "created",
         UPDATED: "updated",

--- a/web/js/config.js
+++ b/web/js/config.js
@@ -8,15 +8,14 @@ import ToolsCatalog from './toolsCatalog.js';
 export default {
     URLS: {
         //TODO Bring in internal TT.  Register as a new application for RERUM dev.  
-        CREATE: "http://tinydev.rerum.io/app/create",
-        UPDATE: "http://tinydev.rerum.io/app/update",
-        PATCH: "http://tinydev.rerum.io/app/patch",
-        OVERWRITE: "http://tinydev.rerum.io/app/overwrite",
-        QUERY: "http://tinydev.rerum.io/app/query",
-        SINCE: "http://devstore.rerum.io/v1/since",
-        HISTORY: "http://devstore.rerum.io/v1/history",
-        SEARCH_TEXT: "https://devstore.rerum.io/v1/api/search/text",
-        SEARCH_TEXT_FALLBACK: "https://devstore.rerum.io/v1/api/search",
+        CREATE: "https://tinydev.rerum.io/app/create",
+        UPDATE: "https://tinydev.rerum.io/app/update",
+        PATCH: "https://tinydev.rerum.io/app/patch",
+        OVERWRITE: "https://tinydev.rerum.io/app/overwrite",
+        QUERY: "https://tinydev.rerum.io/app/query",
+        SINCE: "https://devstore.rerum.io/v1/since",
+        HISTORY: "https://devstore.rerum.io/v1/history",
+        SEARCH_TEXT: "https://devstore.rerum.io/v1/api/search",
         SEARCH_PHRASE: "https://devstore.rerum.io/v1/api/search/phrase"
     },
     /** Max page size for RERUM search (API recommends ≤ 100). */
@@ -25,6 +24,8 @@ export default {
     SEARCH_COOLDOWN_MS: 500,
     /** Cache repeated identical queries briefly to reduce expensive duplicate calls. */
     SEARCH_CACHE_TTL_MS: 60_000,
+    /** Safety cap for page fetches per search request. */
+    SEARCH_MAX_PAGES: 50,
     EVENTS: {
         CREATED: "created",
         UPDATED: "updated",

--- a/web/js/services/searchService.js
+++ b/web/js/services/searchService.js
@@ -1,6 +1,6 @@
 /**
  * Search service for RERUM annotation text and phrase search.
- * Uses /search/text and /search/phrase endpoints with pagination (limit ≤ 100)
+ * Uses /search and /search/phrase endpoints with pagination (limit ≤ 100)
  * and normalizes results for the frontend.
  */
 import CONFIG from "../config.js";
@@ -8,15 +8,30 @@ import CONFIG from "../config.js";
 const PAGE_LIMIT = Math.min(100, CONFIG.SEARCH_PAGE_LIMIT ?? 100);
 const SEARCH_COOLDOWN_MS = CONFIG.SEARCH_COOLDOWN_MS ?? 500;
 const SEARCH_CACHE_TTL_MS = CONFIG.SEARCH_CACHE_TTL_MS ?? 60_000;
+const SEARCH_CACHE_MAX_ENTRIES = CONFIG.SEARCH_CACHE_MAX_ENTRIES ?? 200;
+const SEARCH_MAX_PAGES = CONFIG.SEARCH_MAX_PAGES ?? 50;
 
 const searchCache = new Map();
 let lastSearchAt = 0;
+
+function pruneSearchCache(now = Date.now()) {
+    for (const [key, value] of searchCache.entries()) {
+        if (now - value.cachedAt >= SEARCH_CACHE_TTL_MS) {
+            searchCache.delete(key);
+        }
+    }
+    while (searchCache.size > SEARCH_CACHE_MAX_ENTRIES) {
+        const oldestKey = searchCache.keys().next().value;
+        if (!oldestKey) break;
+        searchCache.delete(oldestKey);
+    }
+}
 
 /**
  * Normalize a single RERUM annotation hit into a consistent shape.
  * Handles Web Annotation and IIIF body/target shapes.
  * @param {object} hit - Raw annotation from RERUM search response
- * @returns {{ id: string, bodyText: string, targetUri: string | null, score: number | null }}
+ * @returns {{ id: string, annotationId: string, bodyText: string, snippet: string, targetUri: string | null, score: number | null }}
  */
 function normalizeHit(hit) {
     if (!hit || typeof hit !== "object") {
@@ -76,6 +91,7 @@ function normalizeHit(hit) {
  * @param {string} url - Base URL (with optional query already)
  * @param {string} query - Search text
  * @param {number} skip - Offset for pagination
+ * @param {{ mode: "object"|"string", bodyKey: string | null }} payload - How to encode the search body
  * @returns {Promise<object[]>} Raw annotation array (may be empty)
  */
 async function fetchSearchPage(url, query, skip, payload) {
@@ -86,9 +102,13 @@ async function fetchSearchPage(url, query, skip, payload) {
         payload.mode === "string"
             ? query
             : JSON.stringify({ [payload.bodyKey]: query });
+    const contentType =
+        payload.mode === "string"
+            ? "text/plain; charset=utf-8"
+            : "application/json; charset=utf-8";
     const response = await fetch(pageUrl, {
         method: "POST",
-        headers: { "Content-Type": "application/json; charset=utf-8" },
+        headers: { "Content-Type": contentType },
         body,
     });
     if (!response.ok) {
@@ -120,16 +140,21 @@ function extractHits(data) {
  * Run paged search until no more results (limit applied per request, never > 100).
  * @param {string} baseUrl - CONFIG.URLS.SEARCH_TEXT or SEARCH_PHRASE
  * @param {string} query - Search text
+ * @param {{ mode: "object"|"string", bodyKey: string | null }} payload - How to encode the search body
+ * @param {number} startSkip - Initial offset for pagination
+ * @param {object[]} initialResults - Optional already-fetched first page
  * @returns {Promise<object[]>} All raw annotation hits
  */
-async function fetchAllPages(baseUrl, query, payload) {
-    const all = [];
-    let skip = 0;
-    while (true) {
+async function fetchAllPages(baseUrl, query, payload, startSkip = 0, initialResults = []) {
+    const all = [...initialResults];
+    let skip = startSkip;
+    let pages = initialResults.length > 0 ? 1 : 0;
+    while (pages < SEARCH_MAX_PAGES) {
         const page = await fetchSearchPage(baseUrl, query, skip, payload);
         if (!page.length) break;
         all.push(...page);
         skip += page.length;
+        pages += 1;
     }
     return all;
 }
@@ -159,7 +184,7 @@ async function fetchAllPagesWithFallback(urls, query, searchType) {
             try {
                 const firstPage = await fetchSearchPage(url, query, 0, payload);
                 if (firstPage.length > 0) {
-                    const rest = await fetchAllPages(url, query, payload);
+                    const rest = await fetchAllPages(url, query, payload, firstPage.length, firstPage);
                     return rest;
                 }
                 sawEmptyResults = true;
@@ -182,7 +207,7 @@ async function fetchAllPagesWithFallback(urls, query, searchType) {
  *
  * @param {string} query - Search query (plain text or phrase)
  * @param {"text"|"phrase"} searchType - "text" for full-text, "phrase" for phrase search
- * @returns {Promise<{ results: Array<{ id: string, bodyText: string, targetUri: string | null, score: number | null }>, error: string | null }>}
+ * @returns {Promise<{ results: Array<{ id: string, annotationId: string, bodyText: string, snippet: string, targetUri: string | null, score: number | null }>, error: string | null }>}
  *   Normalized result object; `error` is set on API or empty-query failure, `results` empty in that case.
  */
 export async function searchAnnotations(query, searchType = "text") {
@@ -205,7 +230,7 @@ export async function searchAnnotations(query, searchType = "text") {
     const endpointCandidates =
         searchType === "phrase"
             ? [CONFIG.URLS.SEARCH_PHRASE]
-            : [CONFIG.URLS.SEARCH_TEXT, CONFIG.URLS.SEARCH_TEXT_FALLBACK];
+            : [CONFIG.URLS.SEARCH_TEXT];
     const urls = endpointCandidates.filter(Boolean);
 
     if (!urls.length) {
@@ -215,9 +240,13 @@ export async function searchAnnotations(query, searchType = "text") {
 
     const cacheKey = `${searchType}::${trimmed}`;
     const now = Date.now();
+    pruneSearchCache(now);
     const cached = searchCache.get(cacheKey);
     if (cached && now - cached.cachedAt < SEARCH_CACHE_TTL_MS) {
-        return { ...cached.value };
+        return {
+            error: cached.value.error,
+            results: [...cached.value.results],
+        };
     }
     if (now - lastSearchAt < SEARCH_COOLDOWN_MS) {
         normalized.error = "Please wait a moment before searching again.";
@@ -228,7 +257,14 @@ export async function searchAnnotations(query, searchType = "text") {
     try {
         const rawHits = await fetchAllPagesWithFallback(urls, trimmed, searchType);
         normalized.results = rawHits.map(normalizeHit);
-        searchCache.set(cacheKey, { cachedAt: Date.now(), value: { ...normalized } });
+        searchCache.set(cacheKey, {
+            cachedAt: Date.now(),
+            value: {
+                error: normalized.error,
+                results: [...normalized.results],
+            },
+        });
+        pruneSearchCache();
         return normalized;
     } catch (err) {
         normalized.error = err instanceof Error ? err.message : String(err);

--- a/web/js/services/searchService.js
+++ b/web/js/services/searchService.js
@@ -1,0 +1,187 @@
+/**
+ * Search service for RERUM annotation text and phrase search.
+ * Uses /search/text and /search/phrase endpoints with pagination (limit ≤ 100)
+ * and normalizes results for the frontend.
+ */
+import CONFIG from "../config.js";
+
+const PAGE_LIMIT = Math.min(100, CONFIG.SEARCH_PAGE_LIMIT ?? 100);
+const SEARCH_COOLDOWN_MS = CONFIG.SEARCH_COOLDOWN_MS ?? 500;
+const SEARCH_CACHE_TTL_MS = CONFIG.SEARCH_CACHE_TTL_MS ?? 60_000;
+
+const searchCache = new Map();
+let lastSearchAt = 0;
+
+/**
+ * Normalize a single RERUM annotation hit into a consistent shape.
+ * Handles Web Annotation and IIIF body/target shapes.
+ * @param {object} hit - Raw annotation from RERUM search response
+ * @returns {{ id: string, bodyText: string, targetUri: string | null, score: number | null }}
+ */
+function normalizeHit(hit) {
+    if (!hit || typeof hit !== "object") {
+        return {
+            id: "",
+            annotationId: "",
+            bodyText: "",
+            snippet: "",
+            targetUri: null,
+            score: null,
+        };
+    }
+    const id = hit["@id"] ?? hit.id ?? "";
+    const score = hit.__rerum?.score ?? null;
+
+    let bodyText = "";
+    if (typeof hit.bodyValue === "string") {
+        bodyText = hit.bodyValue;
+    } else if (hit.body?.value) {
+        bodyText = typeof hit.body.value === "string" ? hit.body.value : "";
+    } else if (Array.isArray(hit.body)) {
+        const first = hit.body.find((b) => b?.value);
+        bodyText = typeof first?.value === "string" ? first.value : "";
+    }
+    if (!bodyText && hit.resource?.chars) {
+        bodyText = typeof hit.resource.chars === "string" ? hit.resource.chars : "";
+    }
+    if (!bodyText && hit.resource?.["cnt:chars"]) {
+        bodyText = typeof hit.resource["cnt:chars"] === "string" ? hit.resource["cnt:chars"] : "";
+    }
+
+    let targetUri = null;
+    const target = hit.target;
+    if (typeof target === "string") {
+        targetUri = target;
+    } else if (target?.source) {
+        targetUri = typeof target.source === "string" ? target.source : target.source?.id ?? null;
+    } else if (target?.id) {
+        targetUri = target.id;
+    } else if (Array.isArray(target) && target.length) {
+        const first = target[0];
+        targetUri = typeof first === "string" ? first : first?.source ?? first?.id ?? null;
+    }
+
+    return {
+        id,
+        annotationId: id,
+        bodyText,
+        snippet: bodyText,
+        targetUri,
+        score,
+    };
+}
+
+/**
+ * Fetch one page of search results.
+ * @param {string} url - Base URL (with optional query already)
+ * @param {string} query - Search text
+ * @param {number} skip - Offset for pagination
+ * @returns {Promise<object[]>} Raw annotation array (may be empty)
+ */
+async function fetchSearchPage(url, query, skip) {
+    const limit = PAGE_LIMIT;
+    const sep = url.includes("?") ? "&" : "?";
+    const pageUrl = `${url}${sep}limit=${limit}&skip=${skip}`;
+    const body = JSON.stringify({ searchText: query });
+    const response = await fetch(pageUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        body,
+    });
+    if (!response.ok) {
+        const msg = `Search API error: ${response.status} ${response.statusText}`;
+        throw new Error(msg);
+    }
+    const data = await response.json();
+    return extractHits(data);
+}
+
+/**
+ * Extract array hits from known RERUM response shapes.
+ * @param {unknown} data - Parsed JSON response
+ * @returns {object[]} Raw hit array
+ */
+function extractHits(data) {
+    if (Array.isArray(data)) return data;
+    if (!data || typeof data !== "object") return [];
+    if (Array.isArray(data.items)) return data.items;
+    if (Array.isArray(data.results)) return data.results;
+    if (Array.isArray(data.hits)) return data.hits;
+    return [];
+}
+
+/**
+ * Run paged search until no more results (limit applied per request, never > 100).
+ * @param {string} baseUrl - CONFIG.URLS.SEARCH_TEXT or SEARCH_PHRASE
+ * @param {string} query - Search text
+ * @returns {Promise<object[]>} All raw annotation hits
+ */
+async function fetchAllPages(baseUrl, query) {
+    const all = [];
+    let skip = 0;
+    while (true) {
+        const page = await fetchSearchPage(baseUrl, query, skip);
+        if (!page.length) break;
+        all.push(...page);
+        skip += page.length;
+    }
+    return all;
+}
+
+/**
+ * Search RERUM annotations by text or phrase and return normalized results.
+ * Pagination is handled internally (limit ≤ 100 per request); all pages are fetched.
+ *
+ * @param {string} query - Search query (plain text or phrase)
+ * @param {"text"|"phrase"} searchType - "text" for full-text, "phrase" for phrase search
+ * @returns {Promise<{ results: Array<{ id: string, bodyText: string, targetUri: string | null, score: number | null }>, error: string | null }>}
+ *   Normalized result object; `error` is set on API or empty-query failure, `results` empty in that case.
+ */
+export async function searchAnnotations(query, searchType = "text") {
+    const normalized = {
+        results: [],
+        error: null,
+    };
+
+    const trimmed = typeof query === "string" ? query.trim() : "";
+    if (!trimmed) {
+        normalized.error = "Search query is required.";
+        return normalized;
+    }
+
+    if (searchType !== "text" && searchType !== "phrase") {
+        normalized.error = "searchType must be 'text' or 'phrase'.";
+        return normalized;
+    }
+
+    const url = searchType === "phrase" ? CONFIG.URLS.SEARCH_PHRASE : CONFIG.URLS.SEARCH_TEXT;
+    if (!url) {
+        normalized.error = "Search endpoint not configured.";
+        return normalized;
+    }
+
+    const cacheKey = `${searchType}::${trimmed}`;
+    const now = Date.now();
+    const cached = searchCache.get(cacheKey);
+    if (cached && now - cached.cachedAt < SEARCH_CACHE_TTL_MS) {
+        return { ...cached.value };
+    }
+    if (now - lastSearchAt < SEARCH_COOLDOWN_MS) {
+        normalized.error = "Please wait a moment before searching again.";
+        return normalized;
+    }
+    lastSearchAt = now;
+
+    try {
+        const rawHits = await fetchAllPages(url, trimmed);
+        normalized.results = rawHits.map(normalizeHit);
+        searchCache.set(cacheKey, { cachedAt: Date.now(), value: { ...normalized } });
+        return normalized;
+    } catch (err) {
+        normalized.error = err instanceof Error ? err.message : String(err);
+        normalized.results = [];
+        return normalized;
+    }
+}
+
+export { normalizeHit, extractHits, PAGE_LIMIT };

--- a/web/js/services/searchService.js
+++ b/web/js/services/searchService.js
@@ -78,19 +78,23 @@ function normalizeHit(hit) {
  * @param {number} skip - Offset for pagination
  * @returns {Promise<object[]>} Raw annotation array (may be empty)
  */
-async function fetchSearchPage(url, query, skip) {
+async function fetchSearchPage(url, query, skip, payload) {
     const limit = PAGE_LIMIT;
     const sep = url.includes("?") ? "&" : "?";
     const pageUrl = `${url}${sep}limit=${limit}&skip=${skip}`;
-    const body = JSON.stringify({ searchText: query });
+    const body =
+        payload.mode === "string"
+            ? query
+            : JSON.stringify({ [payload.bodyKey]: query });
     const response = await fetch(pageUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json; charset=utf-8" },
         body,
     });
     if (!response.ok) {
-        const msg = `Search API error: ${response.status} ${response.statusText}`;
-        throw new Error(msg);
+        const err = new Error(`Search API error: ${response.status} ${response.statusText}`);
+        err.status = response.status;
+        throw err;
     }
     const data = await response.json();
     return extractHits(data);
@@ -107,6 +111,8 @@ function extractHits(data) {
     if (Array.isArray(data.items)) return data.items;
     if (Array.isArray(data.results)) return data.results;
     if (Array.isArray(data.hits)) return data.hits;
+    if (Array.isArray(data.docs)) return data.docs;
+    if (Array.isArray(data["@graph"])) return data["@graph"];
     return [];
 }
 
@@ -116,16 +122,58 @@ function extractHits(data) {
  * @param {string} query - Search text
  * @returns {Promise<object[]>} All raw annotation hits
  */
-async function fetchAllPages(baseUrl, query) {
+async function fetchAllPages(baseUrl, query, payload) {
     const all = [];
     let skip = 0;
     while (true) {
-        const page = await fetchSearchPage(baseUrl, query, skip);
+        const page = await fetchSearchPage(baseUrl, query, skip, payload);
         if (!page.length) break;
         all.push(...page);
         skip += page.length;
     }
     return all;
+}
+
+function getPayloadCandidates(searchType) {
+    const bodyKeys =
+        searchType === "phrase"
+            ? ["phrase", "searchText", "text", "query"]
+            : ["searchText", "text", "query"];
+    const objectPayloads = bodyKeys.map((bodyKey) => ({ mode: "object", bodyKey }));
+    return [...objectPayloads, { mode: "string", bodyKey: null }];
+}
+
+/**
+ * Try one or more endpoint URLs. If an endpoint responds with 404, try next.
+ * @param {string[]} urls - candidate search endpoint URLs
+ * @param {string} query - Search query
+ * @returns {Promise<object[]>}
+ */
+async function fetchAllPagesWithFallback(urls, query, searchType) {
+    let lastError = null;
+    let sawEmptyResults = false;
+    const payloadCandidates = getPayloadCandidates(searchType);
+
+    for (const url of urls) {
+        for (const payload of payloadCandidates) {
+            try {
+                const firstPage = await fetchSearchPage(url, query, 0, payload);
+                if (firstPage.length > 0) {
+                    const rest = await fetchAllPages(url, query, payload);
+                    return rest;
+                }
+                sawEmptyResults = true;
+            } catch (err) {
+                lastError = err;
+                if (err?.status === 404) {
+                    break;
+                }
+                throw err;
+            }
+        }
+    }
+    if (sawEmptyResults) return [];
+    throw lastError ?? new Error("Search API error: no usable endpoint.");
 }
 
 /**
@@ -154,8 +202,13 @@ export async function searchAnnotations(query, searchType = "text") {
         return normalized;
     }
 
-    const url = searchType === "phrase" ? CONFIG.URLS.SEARCH_PHRASE : CONFIG.URLS.SEARCH_TEXT;
-    if (!url) {
+    const endpointCandidates =
+        searchType === "phrase"
+            ? [CONFIG.URLS.SEARCH_PHRASE]
+            : [CONFIG.URLS.SEARCH_TEXT, CONFIG.URLS.SEARCH_TEXT_FALLBACK];
+    const urls = endpointCandidates.filter(Boolean);
+
+    if (!urls.length) {
         normalized.error = "Search endpoint not configured.";
         return normalized;
     }
@@ -173,7 +226,7 @@ export async function searchAnnotations(query, searchType = "text") {
     lastSearchAt = now;
 
     try {
-        const rawHits = await fetchAllPages(url, trimmed);
+        const rawHits = await fetchAllPagesWithFallback(urls, trimmed, searchType);
         normalized.results = rawHits.map(normalizeHit);
         searchCache.set(cacheKey, { cachedAt: Date.now(), value: { ...normalized } });
         return normalized;
@@ -184,4 +237,4 @@ export async function searchAnnotations(query, searchType = "text") {
     }
 }
 
-export { normalizeHit, extractHits, PAGE_LIMIT };
+export { normalizeHit, extractHits, PAGE_LIMIT, fetchAllPagesWithFallback };

--- a/web/search-test.html
+++ b/web/search-test.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Search service test – Rerum Playground</title>
+    <style>
+        body { font-family: system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; }
+        h1 { font-size: 1.25rem; }
+        label { display: block; margin-top: 1rem; }
+        input, select, button { margin-top: 0.25rem; padding: 0.5rem; }
+        button { cursor: pointer; }
+        #out { margin-top: 1rem; white-space: pre-wrap; word-break: break-all; font-size: 0.9rem; }
+        .error { color: #c00; }
+        .meta { color: #666; font-size: 0.85rem; margin-top: 0.5rem; }
+    </style>
+</head>
+<body>
+    <h1>Annotation search test</h1>
+    <p>Uses <code>searchService.searchAnnotations()</code> against RERUM dev store. Serve this file (e.g. Live Server) so modules load.</p>
+    <label>
+        Query
+        <input type="text" id="query" value="annotation" placeholder="e.g. manuscript">
+    </label>
+    <label>
+        Type
+        <select id="type">
+            <option value="text">text</option>
+            <option value="phrase">phrase</option>
+        </select>
+    </label>
+    <button type="button" id="run">Search</button>
+    <div id="out"></div>
+
+    <script type="module">
+        import { searchAnnotations } from './js/services/searchService.js';
+
+        const queryEl = document.getElementById('query');
+        const typeEl = document.getElementById('type');
+        const runEl = document.getElementById('run');
+        const outEl = document.getElementById('out');
+
+        function log(msg, isError = false) {
+            outEl.textContent = msg;
+            outEl.className = isError ? 'error' : '';
+        }
+
+        runEl.addEventListener('click', async () => {
+            const query = queryEl.value.trim();
+            const searchType = typeEl.value;
+            log('Searching…');
+            runEl.disabled = true;
+            try {
+                const { results, error } = await searchAnnotations(query, searchType);
+                if (error) {
+                    log(`Error: ${error}`, true);
+                    return;
+                }
+                const meta = `Found ${results.length} result(s).\n\n`;
+                let body = results.length
+                    ? results.slice(0, 20).map((r, i) => `${i + 1}. id: ${r.id}\n   body: ${(r.bodyText || '(none)').slice(0, 120)}${r.bodyText && r.bodyText.length > 120 ? '…' : ''}\n   target: ${r.targetUri ?? '(none)'}\n   score: ${r.score ?? '—'}`).join('\n\n')
+                    : '(no results)';
+                if (results.length > 20) body += `\n\n... and ${results.length - 20} more`;
+                log(meta + body);
+            } catch (e) {
+                log(`Exception: ${e.message}`, true);
+            } finally {
+                runEl.disabled = false;
+            }
+        });
+
+        // Expose for console use: window.searchAnnotations(query, type)
+        window.searchAnnotations = searchAnnotations;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
his PR adds the core search logic for issue #115.

Implemented text search and phrase search using RERUM search endpoints
Added pagination with limit/skip and enforced limit <= 100
Fetches all pages until no more results
Normalizes results into a consistent shape:
annotationId
 bodyText / snippet
 targetUri
score
Handles empty results and API errors without crashing
Added basic search test page for manual verification
Manual Test
text search returns results (example: the)
phrase search works with exact phrases
Empty query returns a safe error message
Large result sets are fully paginated and aggregated