### PR TITLE
docs: annotation search contributor guide (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,16 @@ Purpose:
 - Serves as a playground for developers to test app-level behaviors and example workflows without affecting production data.
 
 Main files:
-- `/web/js/sandbox.js` — Contains the sandbox UI logic, including `showSection(id)` to switch visible sandbox panels and placeholder action handlers bound to `.action-btn` elements.
-- `/web/sandbox.html` — The sandbox HTML page that loads the sandbox UI and includes buttons and sections for Create, Read, Update, Overwrite, Delete, and View workflows.
+- `/web/js/components/sandboxUI.js` — `showSection(id)` and placeholder handlers for non-search sandbox actions.
+- `/web/js/components/searchController.js` — Annotation search UI: query handling, loading state, result list rendering, and safe highlighting.
+- `/web/js/services/searchProtection.js` — Wraps the search service with cache, cooldown, and in-flight request deduplication; exports `searchAnnotations` used by the controller.
+- `/web/js/services/searchService.js` — RERUM search HTTP calls, pagination, and `normalizeHit` (pure API layer).
+- `/web/sandbox.html` — Loads the sandbox and search modules.
 
 Documentation:
-- A full reference for the sandbox implementation is available in the project's Docusaurus docs: `docs/docs/sandbox.md` (renders at the docs site as the Sandbox reference page).
+- Technical documentation lives under [`docs/docs/`](docs/docs/). Run `npm run start` from the `docs/` folder to preview the Docusaurus site locally.
+- **Annotation search (contributors):** see [`docs/docs/search-module.md`](docs/docs/search-module.md).
+- Sandbox HTML reference: [`docs/docs/sandbox-html.md`](docs/docs/sandbox-html.md).
 
 ### Usage & setup
 
@@ -73,7 +78,7 @@ You can access and test the Sandbox in two quick ways depending on your needs:
        npm run start
        ```
 
-   4. Open the local site URL printed by the dev server (usually http://localhost:3000) and navigate to the "Sandbox" docs page.
+   4. Open the local site URL printed by the dev server (usually http://localhost:3000) and navigate to the docs.
 
    Note: If `docusaurus` is not recognized, use `npx docusaurus start` as a fallback or ensure dependencies installed correctly. See `docs/package.json` for required packages.
 
@@ -86,11 +91,11 @@ You can access and test the Sandbox in two quick ways depending on your needs:
 ### For contributors
 
 - The Sandbox is intended as an experimentation and testing area for the RERUM Playground. Contributions are welcome — please open issues or pull requests to improve the UI, add real API integrations, or expand the documentation.
-- Documentation changes should be made under the `docs/docs/` folder (for example, `docs/docs/sandbox.md`) so the Docusaurus site can render updates.
+- Documentation changes should be made under the `docs/docs/` folder (for example, `docs/docs/sandbox-html.md`) so the Docusaurus site can render updates.
 
 ### Docs link
 
-View the project's documentation (local Docusaurus site) in `docs/` or the rendered docs when hosted. To quickly find the Sandbox reference in the repo, see: `docs/docs/sandbox.md`.
+View the project's documentation by running the Docusaurus site from the `docs/` folder, or the rendered docs when hosted. The Sandbox HTML reference is at `docs/docs/sandbox-html.md`.
 
 ## Contributing
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 1
+---
+
+# Documentation home
+
+Welcome to the **RERUM Playground** technical documentation. These pages describe HTML structure, configuration, and contributor-facing features of the web app.
+
+## Where to start
+
+- **[About](./about)** — Overview of playground pages.
+- **[Configuration](./config)** — `config.js`, including RERUM URLs and search-related settings.
+- **[Sandbox (HTML)](./sandbox-html)** — Sandbox page structure.
+- **[Annotation search module](./search-module)** — Search stack (`searchController.js`, `searchProtection.js`, `searchService.js`), pagination, caching, and how to extend search.
+
+For repository clone/setup and high-level Sandbox notes, see the [**README**](https://github.com/oss-slu/rerum-playground/blob/dev_devayani/README.md) on the `dev_devayani` branch (or `main`, depending on your workflow).

--- a/docs/docs/search-module.md
+++ b/docs/docs/search-module.md
@@ -1,0 +1,138 @@
+# Annotation search module (contributor guide)
+
+This page matches the **modular search layout** on the `dev_devayani` integration branch: UI lives in `searchController.js`, caching and throttling in `searchProtection.js`, and HTTP/pagination/normalization in `searchService.js`. `sandboxUI.js` only handles generic sandbox section switching and non-search placeholders.
+
+## Architecture overview
+
+Search runs entirely in the browser. There is no server-side “controller”; the roles are split across three modules plus configuration.
+
+```mermaid
+flowchart LR
+  subgraph UI["Search UI"]
+    C["searchController.js — handleSearch, render results"]
+  end
+  subgraph Prot["Protection layer"]
+    P["searchProtection.js — searchAnnotations, cache, cooldown, in-flight dedup"]
+  end
+  subgraph Api["API layer"]
+    S["searchService.js — fetch, paginate, normalizeHit"]
+  end
+  R["RERUM devstore search APIs"]
+  C -->|"searchAnnotations()"| P
+  P -->|"fetchAllPagesWithFallback, normalizeHit, …"| S
+  S --> R
+  R --> S
+  S --> P
+  P --> C
+```
+
+| Layer | Role | Primary file |
+| --- | --- | --- |
+| Sandbox shell | `showSection`, non-search `.action-btn` placeholders | `web/js/components/sandboxUI.js` |
+| Search UI | `handleSearch`, loading UI, `highlightTerms`, `isValidUrl`, truncation, `safeResults` | `web/js/components/searchController.js` |
+| Protection | Validates query, cache TTL, cooldown, in-flight reuse; calls into service | `web/js/services/searchProtection.js` |
+| Search API | POST requests, pagination, payload fallback, `normalizeHit` / `sanitizeHits` / `extractHits` | `web/js/services/searchService.js` |
+| Configuration | URLs and limits | `web/js/config.js` |
+
+`web/sandbox.html` loads `sandboxUI.js` and `searchController.js` as separate modules.
+
+---
+
+## Search “controller” role
+
+1. **`handleSearch` in `searchController.js`**  
+   Reads `#search-query` and `#search-type`, prevents double submission (`isSearchRunning`, disabled button), calls **`searchAnnotations`** from **`searchProtection.js`** (not from `searchService.js` directly), renders errors and result rows, uses **`BODY_TRUNCATE_LENGTH`**, **`highlightTerms`**, and **`isValidUrl`** for links.
+
+2. **`searchAnnotations` in `searchProtection.js`**  
+   Validates input, applies **cache**, **cooldown**, and **in-flight deduplication**, then uses `fetchAllPagesWithFallback`, `sanitizeHits`, and `normalizeHit` from **`searchService.js`** to complete the search.
+
+3. **`searchService.js`**  
+   Stateless HTTP + pagination + normalization only (see file header comment). It does **not** own the cache/cooldown logic on this branch.
+
+---
+
+## Protection layer (two parts)
+
+**API normalization (`searchService.js`)**
+
+- **`normalizeHit`** maps a raw RERUM object to `{ id, annotationId, bodyText, targetUri, score }` (display code uses **`bodyText`** for the body column).  
+- **`sanitizeHits`** / **`extractHits`** harden parsing against varied JSON shapes.
+
+**Runtime protection (`searchProtection.js`)**
+
+- TTL cache, max entries, cooldown between searches, and reuse of in-flight promises for identical keys.
+
+**UI safety (`searchController.js`)**
+
+- **`safeResults`** guards against non-arrays; each row is coerced to `{}` if needed.  
+- Links use **`isValidUrl`** before creating `<a>`.  
+- **`highlightTerms`** builds highlights with the DOM (`DocumentFragment` + `<mark>`), not `innerHTML`.
+
+---
+
+## Pagination strategy
+
+Same as before: `limit`/`skip` on POST requests, pages chained until empty or **`SEARCH_MAX_PAGES`**, with endpoint and JSON body-key fallback via `fetchAllPagesWithFallback` in **`searchService.js`**. **`searchProtection`** invokes that flow after passing validation and cache checks.
+
+---
+
+## Cache, cooldown, and in-flight reuse
+
+Implemented in **`searchProtection.js`** with keys from `config.js` (`SEARCH_CACHE_TTL_MS`, `SEARCH_COOLDOWN_MS`, etc.). Debug logging follows the same pattern as described in config (`SEARCH_DEBUG`, `searchDebug=1`, localhost storage toggle).
+
+---
+
+## RERUM API integration
+
+Endpoints are configured in **`web/js/config.js`** (`SEARCH_TEXT`, `SEARCH_PHRASE`). See **`docs/RERUMAPIDOC.md`** for HTTP details. The browser calls RERUM directly; there is no playground backend proxy.
+
+---
+
+## Example API request and response
+
+**Request (JSON body, first page)**
+
+```http
+POST https://devstore.rerum.io/v1/api/search?limit=100&skip=0 HTTP/1.1
+Content-Type: application/json; charset=utf-8
+
+{"searchText":"medieval manuscript"}
+```
+
+**Illustrative response** (array of annotations; fields vary)
+
+```json
+[
+  {
+    "@id": "https://devstore.rerum.io/v1/id/abcdef1234567890",
+    "body": { "value": "This discusses a medieval manuscript fragment." },
+    "target": "https://example.org/manifest/canvas/1",
+    "__rerum": { "score": 12.34 }
+  }
+]
+```
+
+Normalized rows used in the UI include **`bodyText`** and **`targetUri`** as produced by **`normalizeHit`**.
+
+---
+
+## How to extend search
+
+- **UI changes** (layout, truncation, keyboard shortcuts): **`searchController.js`**.  
+- **Caching / rate limits**: **`searchProtection.js`** and **`config.js`**.  
+- **New endpoints or payload shapes**: **`searchService.js`** (`getPayloadCandidates`, `fetchAllPagesWithFallback`) and **`config.js`** URLs.  
+- **Sandbox section wiring only**: **`sandboxUI.js`** — do not move search logic back into this file; keep the separation.
+
+---
+
+## Related files
+
+| File | Purpose |
+| --- | --- |
+| `web/js/components/searchController.js` | Search UI and `handleSearch` |
+| `web/js/services/searchProtection.js` | `searchAnnotations`, cache, cooldown |
+| `web/js/services/searchService.js` | Fetch, pagination, normalization helpers |
+| `web/js/components/sandboxUI.js` | `showSection`, non-search placeholders |
+| `web/js/config.js` | Endpoints and search tunables |
+| `web/sandbox.html` | Script entry order for sandbox + search |
+| `docs/RERUMAPIDOC.md` | RERUM search API reference |

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -20,7 +20,7 @@ function HomepageHeader() {
           <Link
             className="button button--secondary button--lg"
             to="/docs/intro">
-            Docusaurus Tutorial - 5min ⏱️
+            Browse documentation
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Completes #134 by adding contributor documentation for the annotation search module and aligning the docs site with the current `docs/docs` layout on `main`.

## Changes

- `docs/docs/search-module.md` — Architecture (UI + service), protection layer, pagination, cache/cooldown/in-flight reuse, RERUM integration, example HTTP/JSON, extension points, related files.
- `docs/docs/intro.md` — Project-focused landing page; internal links only to pages that exist (search module); points to GitHub README for setup.
- `docs/src/pages/index.js` — Homepage button: "Browse documentation".
- `README.md` — Links to the search doc and general `docs/docs/` guidance.

## Verification

- `cd docs && npm run build` succeeds.

Closes #134
