### PR TITLE
docs: add search contributor guide and docs intro (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,66 @@ This project allows users to create, interact with, and manage IIIF-compliant JS
 - **`.github/`**: GitHub-specific configuration files for CI workflows.
 - **`README.md`**: Setup and project overview.
 
+## Sandbox Implementation
+
+The Sandbox provides an interactive environment for experimenting with CRUD operations against the RERUM API and for testing JSON payloads and UI interactions before integrating with other tools.
+
+Purpose:
+- Allows users to create, read, update, overwrite, delete, and view JSON objects via a simple UI.
+- Serves as a playground for developers to test app-level behaviors and example workflows without affecting production data.
+
+Main files:
+- `/web/js/sandbox.js` — Contains the sandbox UI logic, including `showSection(id)` to switch visible sandbox panels and placeholder action handlers bound to `.action-btn` elements.
+- `/web/sandbox.html` — The sandbox HTML page that loads the sandbox UI and includes buttons and sections for Create, Read, Update, Overwrite, Delete, and View workflows.
+
+Documentation:
+- Technical documentation for the project is maintained under [`docs/docs/`](docs/docs/) (Docusaurus). Run `npm run start` from the `docs/` folder to preview it locally.
+- **Annotation search (contributors):** architecture, protection layer, pagination, caching, RERUM integration, API examples, and extension points are documented in [`docs/docs/search-module.md`](docs/docs/search-module.md).
+
+### Usage & setup
+
+You can access and test the Sandbox in two quick ways depending on your needs:
+
+- Open the standalone page (fast, no install):
+
+   1. Use the live-server extension to open sandbox by right-clicking `web/sandbox.html` and choose "Open with Live Server" (recommended).
+   2. The page will open in your browser and the client-side sandbox UI will be available immediately. The sandbox uses client-side placeholders for actions; no server/backend is required to try the UI.
+
+- Run the docs site locally (if you want the Docusaurus docs and integrated site):
+
+   1. Ensure Node.js is >= 18: `node -v` (Docusaurus preset in `docs/package.json` requires Node 18+).
+   2. From the `docs/` folder, install dependencies:
+
+       ```powershell
+       cd docs
+       npm install
+       ```
+
+   3. Start the Docusaurus dev server:
+
+       ```powershell
+       npm run start
+       ```
+
+   4. Open the local site URL printed by the dev server (usually http://localhost:3000) and navigate to the "Sandbox" docs page.
+
+   Note: If `docusaurus` is not recognized, use `npx docusaurus start` as a fallback or ensure dependencies installed correctly. See `docs/package.json` for required packages.
+
+### Dependencies & configuration
+
+- Node.js >= 18 (only required to run the Docusaurus docs site).
+- VS Code Live Server extension (recommended) for quickly opening `web/sandbox.html`.
+- No backend is required to use the placeholder sandbox UI; real CRUD operations would require a reachable RERUM API endpoint and appropriate credentials.
+
+### For contributors
+
+- The Sandbox is intended as an experimentation and testing area for the RERUM Playground. Contributions are welcome — please open issues or pull requests to improve the UI, add real API integrations, or expand the documentation.
+- Documentation changes should be made under the `docs/docs/` folder so the Docusaurus site can render updates.
+
+### Docs link
+
+View the project's documentation by running the Docusaurus site from the `docs/` folder, or the rendered docs when hosted.
+
 ## Contributing
 
 Contributions are welcome! Check out the `CONTRIBUTING.md` for guidelines.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -2,46 +2,18 @@
 sidebar_position: 1
 ---
 
-# Tutorial Intro
+# Documentation home
 
-Let's discover **Docusaurus in less than 5 minutes**.
+Welcome to the **RERUM Playground** documentation site.
 
-## Getting Started
+## Annotation search (contributors)
 
-Get started by **creating a new site**.
+If you are working on sandbox annotation search, start with the **[annotation search module](./search-module)** guide. It explains architecture, the UI and service layers, the protection layer, pagination, caching, RERUM API integration, example requests, and how to extend search.
 
-Or **try Docusaurus immediately** with **[docusaurus.new](https://docusaurus.new)**.
+## Project overview and setup
 
-### What you'll need
+For cloning the repo, running the app, and the Sandbox overview, see the [**README**](https://github.com/oss-slu/rerum-playground/blob/main/README.md) on GitHub.
 
-- [Node.js](https://nodejs.org/en/download/) version 18.0 or above:
-  - When installing Node.js, you are recommended to check all checkboxes related to dependencies.
+## Sidebar tutorials
 
-## Generate a new site
-
-Generate a new Docusaurus site using the **classic template**.
-
-The classic template will automatically be added to your project after you run the command:
-
-```bash
-npm init docusaurus@latest my-website classic
-```
-
-You can type this command into Command Prompt, Powershell, Terminal, or any other integrated terminal of your code editor.
-
-The command also installs all necessary dependencies you need to run Docusaurus.
-
-## Start your site
-
-Run the development server:
-
-```bash
-cd my-website
-npm run start
-```
-
-The `cd` command changes the directory you're working with. In order to work with your newly created Docusaurus site, you'll need to navigate the terminal there.
-
-The `npm run start` command builds your website locally and serves it through a development server, ready for you to view at http://localhost:3000/.
-
-Open `docs/intro.md` (this page) and edit some lines: the site **reloads automatically** and displays your changes.
+The **Tutorial basics** and **Tutorial extras** sections in the sidebar are the default Docusaurus examples. They are useful if you are maintaining or extending this docs site itself.

--- a/docs/docs/search-module.md
+++ b/docs/docs/search-module.md
@@ -1,0 +1,206 @@
+# Annotation search module (contributor guide)
+
+This page explains how annotation text and phrase search works in the RERUM Playground sandbox. It is aimed at contributors who need to debug, extend, or integrate with the feature.
+
+## Architecture overview
+
+Search is implemented entirely in the browser. There is no dedicated backend “search controller” in this repo; orchestration is split between a **UI handler** (sandbox) and a **search service** (HTTP, pagination, caching, normalization).
+
+```mermaid
+flowchart LR
+  subgraph UI["Sandbox UI"]
+    H["handleSearch (sandboxUI.js)"]
+  end
+  subgraph Svc["Search service"]
+    A["searchAnnotations (searchService.js)"]
+    C["Cache + cooldown + in-flight dedup"]
+    P["Pagination + payload fallback"]
+  end
+  R["RERUM devstore search APIs"]
+  H --> A
+  A --> C
+  C --> P
+  P --> R
+  R --> P
+  P --> A
+  A --> H
+```
+
+| Layer | Role | Primary files |
+| --- | --- | --- |
+| UI | Read query and search type, show loading and errors, render results safely | `web/js/components/sandboxUI.js` |
+| Service | Validate input, throttle, cache, call RERUM with pagination, normalize hits | `web/js/services/searchService.js` |
+| Configuration | Endpoint URLs and tunables (limits, TTL, cooldown) | `web/js/config.js` |
+
+---
+
+## Search “controller” role (UI + service)
+
+In server frameworks, a *controller* accepts a request and returns a response. Here, the same responsibilities are shared:
+
+1. **`handleSearch` in `sandboxUI.js`**  
+   - Reads `#search-query` and `#search-type` (`text` or `phrase`).  
+   - Guards against double submission (`isSearchRunning`, disabled button).  
+   - Calls `searchAnnotations(query, searchType)`.  
+   - Renders status messages, result count, and each result row (ID, body snippet, target, score).  
+   - Uses `try` / `finally` so the button is re-enabled even when something throws.
+
+2. **`searchAnnotations` in `searchService.js`**  
+   - Validates non-empty query, max length, and `searchType`.  
+   - Resolves endpoint URL(s) from `CONFIG.URLS.SEARCH_TEXT` or `CONFIG.URLS.SEARCH_PHRASE`.  
+   - Applies cache, in-flight deduplication, and cooldown (see below).  
+   - Fetches all pages via `fetchAllPagesWithFallback`, then maps each raw hit through `normalizeHit`.
+
+Together, these two functions are the public “entry points” for understanding search behavior end to end.
+
+---
+
+## Protection layer (UI safety)
+
+The RERUM API returns JSON arrays of annotation objects, but shapes can vary (Web Annotation vs IIIF-style bodies, string vs object `target`, etc.). The service normalizes hits, and the UI adds a second line of defense so bad rows cannot break the page.
+
+**In `searchService.js`**
+
+- **`normalizeHit`** builds a fixed shape: `id`, `annotationId`, `bodyText`, `snippet`, `targetUri`, `score` (from `__rerum.score` when present). It reads `bodyValue`, `body.value`, array `body`, and some `resource` text fields.  
+- **`sanitizeHits`** drops non-objects.  
+- **`extractHits`** accepts several JSON wrapper shapes (`[]`, `items`, `results`, `hits`, `docs`, `@graph`) so minor API format changes are less likely to crash parsing.
+
+**In `sandboxUI.js`**
+
+- Results are treated as `safeResults = Array.isArray(results) ? results : []`.  
+- Each row is coerced with `const r = row && typeof row === "object" ? row : {}`.  
+- **Links**: `annotationId` and `targetUri` are only turned into `<a href>` when `isValidUrl` passes; otherwise plain text or an em dash is shown.  
+- **Highlighting**: `highlightTerms` uses the DOM (`DocumentFragment`, `mark`) instead of `innerHTML`, so query text cannot inject HTML.
+
+---
+
+## Pagination strategy
+
+RERUM recommends `limit` ≤ 100 per request. The client:
+
+1. Builds a URL with `limit` and `skip` query parameters (see `fetchSearchPage` in `searchService.js`).  
+2. Sends **POST** with either JSON (`Content-Type: application/json`) or a plain string body (`text/plain`), depending on which payload shape the server accepts.  
+3. After the first page, **`fetchAllPages`** loops: each iteration uses `skip` increased by the number of items returned in the previous page, until a page is empty or **`SEARCH_MAX_PAGES`** (default 50) is reached—whichever comes first.
+
+**Endpoint and payload fallback (`fetchAllPagesWithFallback`)**
+
+- Tries multiple JSON property names for the query (`searchText`, `text`, `query`, and for phrase search also `phrase`), then falls back to a **plain string** body if needed.  
+- If the server returns **404** for a URL, the next candidate URL is tried (useful when only one of several possible bases is deployed).
+
+---
+
+## Cache, cooldown, and in-flight reuse
+
+These reduce duplicate work and accidental API hammering (search is expensive on the server).
+
+| Mechanism | Config key(s) | Behavior |
+| --- | --- | --- |
+| **TTL cache** | `SEARCH_CACHE_TTL_MS` (default 60_000), `SEARCH_CACHE_MAX_ENTRIES` (200) | Key = `searchType::trimmedQuery`. Stores the last normalized `{ error, results }`. Expired entries pruned; map trimmed when over max entries. |
+| **Cooldown** | `SEARCH_COOLDOWN_MS` (default 500) | Minimum time between starting new searches (global `lastSearchAt`). |
+| **In-flight dedup** | (in-memory `Map`) | Identical key while a request is running returns the same `Promise` so parallel callers share one network sequence. |
+
+Debug logging for the service is gated by `CONFIG.SEARCH_DEBUG`, `?searchDebug=1`, or `localStorage['rerum:search-debug'] === '1'` on localhost (see `isDebugEnabled` in `searchService.js`).
+
+---
+
+## RERUM API integration
+
+Configured URLs (development store) live in `web/js/config.js`:
+
+- **Text search:** `SEARCH_TEXT` → `https://devstore.rerum.io/v1/api/search`  
+- **Phrase search:** `SEARCH_PHRASE` → `https://devstore.rerum.io/v1/api/search/phrase`
+
+A concise reference for request/response patterns is in the repo at `docs/RERUMAPIDOC.md` (Text Search and Phrase Search sections). Production hosts differ (`https://store.rerum.io/...`); swap URLs in config if you point the playground at production (mind sandbox data warnings in that doc).
+
+---
+
+## Example API request and response
+
+The playground does not expose a server-side route; the browser calls RERUM directly. Examples below match what `searchService.js` generates (text search, first page).
+
+**Request (JSON body)**
+
+```http
+POST https://devstore.rerum.io/v1/api/search?limit=100&skip=0 HTTP/1.1
+Content-Type: application/json; charset=utf-8
+
+{"searchText":"medieval manuscript"}
+```
+
+**Request (plain string body, fallback)**
+
+```http
+POST https://devstore.rerum.io/v1/api/search?limit=100&skip=0 HTTP/1.1
+Content-Type: text/plain; charset=utf-8
+
+medieval manuscript
+```
+
+**Illustrative JSON response** (array of annotations; fields vary by record)
+
+```json
+[
+  {
+    "@id": "https://devstore.rerum.io/v1/id/abcdef1234567890",
+    "body": {
+      "value": "This discusses a medieval manuscript fragment."
+    },
+    "target": "https://example.org/manifest/canvas/1",
+    "__rerum": {
+      "score": 12.34
+    }
+  }
+]
+```
+
+After normalization, the UI consumes objects like:
+
+```json
+{
+  "id": "https://devstore.rerum.io/v1/id/abcdef1234567890",
+  "annotationId": "https://devstore.rerum.io/v1/id/abcdef1234567890",
+  "bodyText": "This discusses a medieval manuscript fragment.",
+  "snippet": "This discusses a medieval manuscript fragment.",
+  "targetUri": "https://example.org/manifest/canvas/1",
+  "score": 12.34
+}
+```
+
+---
+
+## How to extend search
+
+Practical extension points:
+
+1. **New search mode or endpoint**  
+   - Add URL(s) in `config.js`.  
+   - In `searchService.js`, extend `searchAnnotations` (or add a sibling export) to choose URLs and, if needed, new payload shapes in `getPayloadCandidates` / `fetchAllPagesWithFallback`.
+
+2. **Richer result model**  
+   - Extend `normalizeHit` to map additional RERUM fields into the normalized object.  
+   - Update the result loop in `sandboxUI.js` to render new fields; keep using DOM APIs or trusted escaping for any user- or API-sourced strings.
+
+3. **UI behavior**  
+   - Loading state, truncation (`BODY_TRUNCATE_LENGTH`), and highlight rules live in `sandboxUI.js`.  
+   - Phrase vs text highlighting differs: phrase uses the full query as one regex; text splits on whitespace and highlights any term (see `highlightTerms`).
+
+4. **Operational tuning**  
+   - Adjust `SEARCH_PAGE_LIMIT`, `SEARCH_MAX_PAGES`, `SEARCH_CACHE_TTL_MS`, `SEARCH_COOLDOWN_MS`, and `SEARCH_MAX_QUERY_LENGTH` in `config.js` without changing core logic.
+
+5. **Product requirements**  
+   - High-level scope and field-level expectations for “body only” search are summarized in `search-requirements.md` at the repo root (iteration notes).
+
+---
+
+## Related files (quick reference)
+
+| File | Purpose |
+| --- | --- |
+| `web/js/components/sandboxUI.js` | Search UI: `handleSearch`, safe rendering, highlighting |
+| `web/js/services/searchService.js` | API calls, pagination, cache, normalization |
+| `web/js/config.js` | Search URLs and limits |
+| `web/sandbox.html` | Search form markup and script entry |
+| `docs/RERUMAPIDOC.md` | RERUM search HTTP details and examples |
+| `search-requirements.md` | Iteration 1 search requirements |
+
+For general sandbox setup and docs site workflow, see the root `README.md`.

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -20,7 +20,7 @@ function HomepageHeader() {
           <Link
             className="button button--secondary button--lg"
             to="/docs/intro">
-            Docusaurus Tutorial - 5min ⏱️
+            Browse documentation
           </Link>
         </div>
       </div>


### PR DESCRIPTION
- Add docs/docs/search-module.md (architecture, protection layer, pagination, cache, RERUM integration, examples, extension points)
- Replace default Docusaurus intro with a project-focused landing page
- Point docs homepage CTA to Browse documentation
- README: link search-module, sandbox/docs wording aligned with repo layout

Closes #134