### PR TITLE
fixes implementing web annotator ui changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ nbproject/
 build.xml
 *.properties
 CLAUDE.md
+node_modules/

--- a/web/annotator.html
+++ b/web/annotator.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Web Annotator</title>
+  <script src="./js/features/playground.js" type="module"></script>
+  <script src="./js/components/annotatorUI.js" type="module"></script>
+  <link rel="stylesheet" href="./css/playground.css" />
+  <link rel="stylesheet" href="./css/index.css" />
+  <link rel="stylesheet" href="./css/footer.css" />
+  <link rel="stylesheet" href="./css/annotator.css" />
+  <link rel="stylesheet" href="https://unpkg.com/chota@latest" />
+  <link
+    rel="stylesheet"
+    href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css"
+  />
+</head>
+
+<body>
+  <div id="menu-placeholder"></div>
+
+  <header>
+    <div class="header">
+      <div class="row">
+        <button onclick="openCloseMenu()" aria-label="Toggle Menu">&#9776;</button>
+        <img src="logo.png" alt="Rerum Playground" />
+      </div>
+    </div>
+  </header>
+
+  <div class="container">
+    <div class="placeholder" style="height: 50px;"></div>
+
+    <div id="content">
+      <h2>Web Annotator</h2>
+
+      <div class="annotator-intro">
+        <p>
+          A <strong>Web Annotation</strong> is a way to attach a comment, tag, or description
+          to any resource on the web — a web page, image, video, or document — using its URI.
+          Annotations are expressed as <strong>JSON-LD</strong>, a format that links your data
+          to shared vocabularies so machines can understand it too.
+        </p>
+        <p>
+          Fill in the form below to build your own annotation. When you are happy with the
+          preview, you can save it to <strong>RERUM</strong> (a Linked Open Data store) or
+          download it as a file.
+        </p>
+      </div>
+
+      <form class="annotator-form" novalidate>
+        <h3>Build Your Annotation</h3>
+
+        <label for="anno-target">Target URI <span aria-hidden="true">*</span></label>
+        <span class="field-hint">The URL of the resource you want to annotate.</span>
+        <input
+          type="url"
+          id="anno-target"
+          placeholder="https://example.com/resource"
+          aria-required="true"
+          aria-describedby="anno-target-hint"
+        />
+
+        <label for="anno-body">Body Text <span aria-hidden="true">*</span></label>
+        <span class="field-hint">What do you want to say about this resource?</span>
+        <textarea
+          id="anno-body"
+          placeholder="Enter your annotation text here…"
+          aria-required="true"
+        ></textarea>
+
+        <label for="anno-motivation">
+          Motivation
+          <span class="optional-label">(optional)</span>
+        </label>
+        <span class="field-hint">Why are you creating this annotation?</span>
+        <select id="anno-motivation">
+          <option value="commenting">Commenting</option>
+          <option value="describing">Describing</option>
+          <option value="tagging">Tagging</option>
+          <option value="bookmarking">Bookmarking</option>
+        </select>
+
+        <label for="anno-label">
+          Label
+          <span class="optional-label">(optional)</span>
+        </label>
+        <span class="field-hint">A short human-readable name for this annotation.</span>
+        <input
+          type="text"
+          id="anno-label"
+          placeholder="e.g. My note on Charizard"
+        />
+
+        <button type="button" id="generate-btn" class="generate-btn">
+          Generate Annotation
+        </button>
+      </form>
+
+      <div id="anno-status" aria-live="polite" role="status"></div>
+
+      <div id="anno-preview" class="hidden">
+        <h3>Annotation Preview</h3>
+        <pre id="anno-json-output" aria-label="Generated annotation JSON"></pre>
+        <div class="anno-actions">
+          <button type="button" id="save-btn">Save to RERUM</button>
+          <button type="button" id="download-btn">Download JSON</button>
+          <button type="button" id="reset-btn" class="anno-btn-secondary">Reset</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="footer-placeholder"></div>
+</body>
+</html>

--- a/web/css/annotator.css
+++ b/web/css/annotator.css
@@ -1,0 +1,232 @@
+.container {
+  padding-bottom: 15rem;
+}
+
+.annotator-intro {
+  background: #f9f9f9;
+  border-left: 4px solid #001e3c;
+  border-radius: 4px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.annotator-intro strong {
+  color: #001e3c;
+}
+
+.annotator-form {
+  display: flex;
+  flex-direction: column;
+  max-width: 700px;
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 1.5rem;
+}
+
+.annotator-form h3 {
+  margin-top: 0;
+  color: #001e3c;
+}
+
+.annotator-form label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  color: #001e3c;
+}
+
+.annotator-form .field-hint {
+  display: block;
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: -0.6rem;
+  margin-bottom: 0.8rem;
+}
+
+.annotator-form input,
+.annotator-form textarea,
+.annotator-form select {
+  width: 100%;
+  margin-bottom: 1rem;
+  padding: 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+
+.annotator-form textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.annotator-form input:focus-visible,
+.annotator-form textarea:focus-visible,
+.annotator-form select:focus-visible {
+  outline: 2px solid #003366;
+  outline-offset: 2px;
+}
+
+.annotator-form .optional-label {
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: #666;
+  margin-left: 0.3rem;
+}
+
+.generate-btn {
+  background-color: #001e3c;
+  color: white;
+  border: none;
+  padding: 0.65rem 1.4rem;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  align-self: flex-start;
+}
+
+.generate-btn:hover {
+  background-color: #003366;
+}
+
+.generate-btn:focus-visible {
+  outline: 2px solid #003366;
+  outline-offset: 2px;
+}
+
+/* Preview section */
+#anno-preview {
+  max-width: 700px;
+  margin-top: 1.5rem;
+}
+
+#anno-preview h3 {
+  color: #001e3c;
+  margin-bottom: 0.75rem;
+}
+
+#anno-json-output {
+  background: #1e1e1e;
+  color: #d4d4d4;
+  font-family: monospace;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 1.25rem;
+  border-radius: 6px;
+  margin: 0 0 1rem;
+  overflow-x: auto;
+}
+
+.anno-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.anno-actions button {
+  background-color: #001e3c;
+  color: white;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.anno-actions button:hover {
+  background-color: #003366;
+}
+
+.anno-actions button:focus-visible {
+  outline: 2px solid #003366;
+  outline-offset: 2px;
+}
+
+.anno-btn-secondary {
+  background-color: transparent !important;
+  color: #001e3c !important;
+  border: 2px solid #001e3c !important;
+  transition: background 0.2s ease, color 0.2s ease !important;
+}
+
+.anno-btn-secondary:hover {
+  background-color: #001e3c !important;
+  color: white !important;
+}
+
+/* Status messages */
+#anno-status {
+  max-width: 700px;
+  margin-top: 1rem;
+  font-size: 0.95rem;
+  min-height: 1.5rem;
+}
+
+.anno-status--success {
+  color: #155724;
+  font-weight: 600;
+}
+
+.anno-status--error {
+  color: #c0392b;
+  font-weight: 600;
+}
+
+.anno-status--info {
+  color: #001e3c;
+  font-style: italic;
+}
+
+.hidden {
+  display: none;
+}
+
+/* Spinner */
+.anno-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+.anno-spinner {
+  width: 20px;
+  height: 20px;
+  border: 3px solid #f3f3f3;
+  border-top: 3px solid #003366;
+  border-radius: 50%;
+  animation: anno-spin 1s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes anno-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .anno-spinner {
+    animation: none;
+    border-top-color: #003366;
+    opacity: 0.7;
+  }
+}
+
+@media (max-width: 600px) {
+  .anno-actions {
+    flex-direction: column;
+  }
+
+  .anno-actions button {
+    width: 100%;
+  }
+}

--- a/web/js/components/annotatorUI.js
+++ b/web/js/components/annotatorUI.js
@@ -1,0 +1,133 @@
+import { create } from '../services/objectService.js';
+
+let currentAnnotation = null;
+
+function isValidUrl(str) {
+  try {
+    new URL(str);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function setStatus(message, type = 'info') {
+  const el = document.getElementById('anno-status');
+  el.textContent = message;
+  el.className = `anno-status--${type}`;
+}
+
+function clearStatus() {
+  const el = document.getElementById('anno-status');
+  el.textContent = '';
+  el.className = '';
+}
+
+export function buildAnnotation(target, bodyText, label, motivation) {
+  const annotation = {
+    '@context': 'https://www.w3.org/ns/anno.jsonld',
+    'type': 'Annotation',
+    'motivation': motivation || 'commenting',
+    'body': {
+      'type': 'TextualBody',
+      'value': bodyText,
+      'format': 'text/plain',
+      'language': 'en'
+    },
+    'target': target
+  };
+  if (label) {
+    annotation.label = label;
+  }
+  return annotation;
+}
+
+function handleGenerate() {
+  const target = document.getElementById('anno-target').value.trim();
+  const bodyText = document.getElementById('anno-body').value.trim();
+  const label = document.getElementById('anno-label').value.trim();
+  const motivation = document.getElementById('anno-motivation').value;
+
+  if (!target) {
+    setStatus('Please enter a Target URI.', 'error');
+    document.getElementById('anno-target').focus();
+    return;
+  }
+  if (!isValidUrl(target)) {
+    setStatus('Target URI must be a valid URL (e.g. https://example.com/page).', 'error');
+    document.getElementById('anno-target').focus();
+    return;
+  }
+  if (!bodyText) {
+    setStatus('Please enter body text.', 'error');
+    document.getElementById('anno-body').focus();
+    return;
+  }
+
+  currentAnnotation = buildAnnotation(target, bodyText, label, motivation);
+
+  document.getElementById('anno-json-output').textContent =
+    JSON.stringify(currentAnnotation, null, 2);
+
+  const preview = document.getElementById('anno-preview');
+  preview.classList.remove('hidden');
+  preview.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+  document.getElementById('save-btn').disabled = false;
+  clearStatus();
+}
+
+async function handleSave() {
+  if (!currentAnnotation) return;
+
+  const saveBtn = document.getElementById('save-btn');
+  saveBtn.disabled = true;
+
+  const loadingEl = document.createElement('div');
+  loadingEl.className = 'anno-loading';
+  loadingEl.innerHTML = '<div class="anno-spinner" aria-hidden="true"></div><span>Saving to RERUM…</span>';
+  document.getElementById('anno-status').replaceChildren(loadingEl);
+
+  try {
+    const result = await create(currentAnnotation);
+    if (result instanceof Error) {
+      throw result;
+    }
+    const uri = result?.['@id'] ?? result?.id ?? JSON.stringify(result);
+    setStatus(`Saved! RERUM URI: ${uri}`, 'success');
+  } catch (err) {
+    setStatus(`Save failed: ${err.message}`, 'error');
+    saveBtn.disabled = false;
+  }
+}
+
+function handleDownload() {
+  if (!currentAnnotation) return;
+  const json = JSON.stringify(currentAnnotation, null, 2);
+  const blob = new Blob([json], { type: 'application/ld+json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'annotation.jsonld';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function handleReset() {
+  document.getElementById('anno-target').value = '';
+  document.getElementById('anno-body').value = '';
+  document.getElementById('anno-label').value = '';
+  document.getElementById('anno-motivation').value = 'commenting';
+  document.getElementById('anno-preview').classList.add('hidden');
+  document.getElementById('anno-json-output').textContent = '';
+  currentAnnotation = null;
+  clearStatus();
+  document.getElementById('anno-target').focus();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('generate-btn').addEventListener('click', handleGenerate);
+  document.getElementById('save-btn').addEventListener('click', handleSave);
+  document.getElementById('download-btn').addEventListener('click', handleDownload);
+  document.getElementById('reset-btn').addEventListener('click', handleReset);
+});


### PR DESCRIPTION
 ## Changes                                                                    
  - `web/annotator.html` — New page with form, JSON preview, and save/download
  actions
  - `web/js/components/annotatorUI.js` — Builds JSON-LD 1.1 compliant
  annotation, handles RERUM save and file download                              
  - `web/css/annotator.css` — Page-specific styles matching existing playground
  theme                                                                         
  - `.gitignore` — Added `node_modules/` (was missing, caused ~7k phantom
  changes)                                                                      
   
  ## Acceptance Criteria                                                        
  - [x] User can input a target URI                         
  - [x] User can input body text
  - [x] Clicking "Generate Annotation" produces valid JSON-LD structure with
  `@context: https://www.w3.org/ns/anno.jsonld`                                 
  - [x] JSON renders correctly in preview
  - [x] User can save to RERUM or download as `annotation.jsonld`    