### PR TITLE
fixing issue #141

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ nbproject/
 build.xml
 *.properties
 CLAUDE.md
+node_modules/

--- a/docs/docs/annotator.md
+++ b/docs/docs/annotator.md
@@ -1,0 +1,107 @@
+# Web Annotator
+
+## Purpose
+
+The Web Annotator page (`annotator.html`) lets users build, preview, and save
+[W3C Web Annotations](https://www.w3.org/TR/annotation-model/) against the RERUM API.
+It is the interactive companion to the Sandbox for annotation-specific work.
+
+---
+
+## Module Architecture
+
+```
+annotator.html
+├── js/features/playground.js       (shared — menu/footer injection, sidebar toggle)
+└── js/components/annotatorUI.js   (form wiring, live preview, RERUM save)
+    ├── js/annotationTemplate.js   (JSON-LD template constant + buildAnnotation())
+    ├── js/services/objectService.js  (create() — POST to RERUM)
+    └── js/config.js               (URLS.CREATE, EVENTS.CREATED)
+```
+
+**Data flow:**
+1. User fills form fields (body text, target URI, motivation, language).
+2. `annotatorUI.js` calls `buildAnnotation()` on each `input` event → updates the live `<pre>` preview.
+3. "Save to RERUM" button (enabled only when required fields are filled) calls `create(annotation)`.
+4. On success, the RERUM-assigned URI is shown and a `EVENTS.CREATED` CustomEvent is dispatched on `document`.
+
+---
+
+## JSON-LD 1.1 Annotation Template
+
+Minimal valid Web Annotation per [https://www.w3.org/ns/anno.jsonld](https://www.w3.org/ns/anno.jsonld):
+
+```json
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "type": "Annotation",
+  "motivation": "commenting",
+  "body": {
+    "type": "TextualBody",
+    "value": "",
+    "format": "text/plain",
+    "language": "en"
+  },
+  "target": ""
+}
+```
+
+### Required fields
+
+| Field | Maps to (Linked Data) | Notes |
+|---|---|---|
+| `@context` | — | `"http://www.w3.org/ns/anno.jsonld"` — JSON-LD 1.1 context declaration |
+| `type` | `oa:Annotation` | Identifies the resource as a Web Annotation |
+| `body` | `oa:hasBody` | The annotation content |
+| `target` | `oa:hasTarget` | URI of the resource being annotated |
+
+### Body properties with context definitions
+
+| Property | Linked Data URI | Description |
+|---|---|---|
+| `body.type` (`TextualBody`) | `oa:TextualBody` — http://www.w3.org/ns/oa#TextualBody | Body resource type |
+| `body.value` | `rdf:value` — http://www.w3.org/1999/02/22-rdf-syntax-ns#value | The plain-text content |
+| `body.format` | `dc:format` — http://purl.org/dc/elements/1.1/format | MIME type (always `text/plain` here) |
+| `body.language` | `dc:language` — http://purl.org/dc/elements/1.1/language | BCP47 language tag |
+| `motivation` | `oa:motivatedBy` — http://www.w3.org/ns/oa#motivatedBy | Reason for the annotation |
+
+The `id` field (`@id`) is assigned by RERUM after a successful `CREATE` call.
+
+---
+
+## `annotationTemplate.js` Exports
+
+| Export | Type | Description |
+|---|---|---|
+| `ANNOTATION_CONTEXT` | `string` | `"http://www.w3.org/ns/anno.jsonld"` |
+| `MOTIVATIONS` | frozen object | Allowed `oa:motivatedBy` values: `commenting`, `tagging`, `describing`, `identifying`, `classifying` |
+| `MINIMAL_ANNOTATION_TEMPLATE` | frozen object | Empty template for reference and display |
+| `buildAnnotation(bodyText, targetUri, motivation?, language?)` | function | Returns a new annotation object; throws if required fields are missing |
+
+---
+
+## Validation
+
+To manually validate the JSON-LD structure:
+
+1. Build an annotation using the form.
+2. Copy the preview JSON.
+3. Paste it into the [JSON-LD Playground](https://json-ld.org/playground/).
+4. Confirm that all body properties expand to their full linked-data URIs under the `http://www.w3.org/ns/anno.jsonld` context.
+
+---
+
+## Linked Files
+
+**JavaScript**
+- `js/features/playground.js`
+- `js/components/annotatorUI.js`
+- `js/annotationTemplate.js`
+- `js/services/objectService.js`
+- `js/config.js`
+
+**CSS**
+- `css/playground.css`
+- `css/annotator.css`
+- `css/index.css`
+- `css/footer.css`

--- a/web/annotator.html
+++ b/web/annotator.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Web Annotator</title>
+  <script src="./js/features/playground.js" type="module"></script>
+  <script src="./js/components/annotatorUI.js" type="module"></script>
+  <link rel="stylesheet" href="./css/playground.css" />
+  <link rel="stylesheet" href="./css/index.css" />
+  <link rel="stylesheet" href="./css/footer.css" />
+  <link rel="stylesheet" href="./css/annotator.css" />
+  <link rel="stylesheet" href="https://unpkg.com/chota@latest" />
+  <link
+    rel="stylesheet"
+    href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css"
+  />
+</head>
+
+<body>
+  <div id="menu-placeholder"></div>
+
+  <header>
+    <div class="header">
+      <div class="row">
+        <button onclick="openCloseMenu()" aria-label="Toggle Menu">&#9776;</button>
+        <img src="logo.png" alt="Rerum Playground" />
+      </div>
+    </div>
+  </header>
+
+  <div class="container">
+    <div class="placeholder" style="height: 50px;"></div>
+
+    <div id="content">
+      <h2>Web Annotator</h2>
+      <p>
+        Build a <a href="https://www.w3.org/TR/annotation-model/" target="_blank" rel="noopener noreferrer">W3C Web Annotation</a>
+        by filling in the form. The live preview shows the JSON-LD 1.1 object that will be saved to RERUM.
+      </p>
+
+      <div class="annotator-layout">
+        <!-- Form panel -->
+        <section class="annotator-form-panel" aria-label="Annotation form">
+          <h3>Annotation Fields</h3>
+
+          <label for="annotator-body">Body Text <span aria-hidden="true">*</span></label>
+          <textarea
+            id="annotator-body"
+            placeholder="Enter the text of your annotation"
+            aria-describedby="annotator-body-help"
+            aria-required="true"
+          ></textarea>
+          <small id="annotator-body-help">
+            The plain-text content of the annotation (<code>body.value</code> → <code>rdf:value</code>).
+          </small>
+
+          <label for="annotator-target">Target URI <span aria-hidden="true">*</span></label>
+          <input
+            id="annotator-target"
+            type="url"
+            placeholder="https://example.org/resource"
+            aria-describedby="annotator-target-help"
+            aria-required="true"
+          />
+          <small id="annotator-target-help">
+            URI of the resource being annotated (<code>target</code> → <code>oa:hasTarget</code>).
+          </small>
+
+          <label for="annotator-motivation">Motivation</label>
+          <select id="annotator-motivation" aria-describedby="annotator-motivation-help">
+            <option value="commenting">commenting</option>
+            <option value="tagging">tagging</option>
+            <option value="describing">describing</option>
+            <option value="identifying">identifying</option>
+            <option value="classifying">classifying</option>
+          </select>
+          <small id="annotator-motivation-help">
+            Reason for the annotation (<code>motivation</code> → <code>oa:motivatedBy</code>).
+          </small>
+
+          <label for="annotator-language">Language</label>
+          <input
+            id="annotator-language"
+            type="text"
+            value="en"
+            placeholder="en"
+            aria-describedby="annotator-language-help"
+          />
+          <small id="annotator-language-help">
+            BCP47 language tag for the body text (<code>body.language</code> → <code>dc:language</code>).
+          </small>
+
+          <div class="annotator-actions">
+            <button id="annotator-save-btn" class="action-btn" disabled aria-describedby="annotator-save-help">
+              Save to RERUM
+            </button>
+          </div>
+          <small id="annotator-save-help">Fill in Body Text and Target URI to enable saving.</small>
+
+          <div id="annotator-status" role="status" aria-live="polite"></div>
+        </section>
+
+        <!-- Preview panel -->
+        <section class="annotator-preview-panel" aria-label="JSON-LD preview">
+          <h3>JSON-LD Preview</h3>
+          <pre id="annotation-preview" aria-label="Live annotation JSON-LD output">{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "type": "Annotation",
+  "motivation": "commenting",
+  "body": {
+    "type": "TextualBody",
+    "value": "",
+    "format": "text/plain",
+    "language": "en"
+  },
+  "target": ""
+}</pre>
+        </section>
+      </div>
+    </div>
+  </div>
+
+  <div id="footer-placeholder"></div>
+</body>
+</html>

--- a/web/css/annotator.css
+++ b/web/css/annotator.css
@@ -1,0 +1,140 @@
+/* Web Annotator page styles */
+
+.annotator-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+/* Form panel */
+.annotator-form-panel {
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 1.5rem;
+}
+
+.annotator-form-panel h3 {
+  margin-top: 0;
+  color: #001e3c;
+}
+
+.annotator-form-panel label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  color: #001e3c;
+}
+
+.annotator-form-panel input,
+.annotator-form-panel textarea,
+.annotator-form-panel select {
+  width: 100%;
+  margin-bottom: 0.4rem;
+  padding: 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: monospace;
+  box-sizing: border-box;
+}
+
+.annotator-form-panel textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.annotator-form-panel small {
+  display: block;
+  color: #555;
+  font-size: 0.8rem;
+  margin-bottom: 1rem;
+}
+
+/* Preview panel */
+.annotator-preview-panel {
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.annotator-preview-panel h3 {
+  margin-top: 0;
+  color: #001e3c;
+}
+
+#annotation-preview {
+  flex: 1;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 1rem;
+  font-family: monospace;
+  font-size: 0.875rem;
+  overflow-x: auto;
+  white-space: pre;
+  color: #001e3c;
+}
+
+/* Action buttons */
+.annotator-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.action-btn {
+  background-color: #001e3c;
+  color: white;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.action-btn:hover:not(:disabled) {
+  background-color: #003366;
+}
+
+.action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Status messages */
+.annotator-status {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  font-style: italic;
+  word-break: break-all;
+}
+
+.annotator-status--success {
+  color: #1a5c2e;
+}
+
+.annotator-status--error {
+  color: #c0392b;
+}
+
+/* Focus states */
+.annotator-form-panel input:focus-visible,
+.annotator-form-panel select:focus-visible,
+.annotator-form-panel textarea:focus-visible,
+.action-btn:focus-visible {
+  outline: 2px solid #003366;
+  outline-offset: 2px;
+}
+
+/* Responsive: stack panels on small screens */
+@media (max-width: 700px) {
+  .annotator-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/js/annotationTemplate.js
+++ b/web/js/annotationTemplate.js
@@ -1,0 +1,81 @@
+/**
+ * W3C Web Annotation Data Model — JSON-LD 1.1 template and builder.
+ * Context reference: https://www.w3.org/ns/anno.jsonld
+ */
+
+/** JSON-LD 1.1 context URI for the W3C Web Annotation vocabulary. */
+export const ANNOTATION_CONTEXT = "http://www.w3.org/ns/anno.jsonld";
+
+/**
+ * Allowed values for oa:motivatedBy.
+ * Each maps to a term defined in the W3C anno context.
+ */
+export const MOTIVATIONS = Object.freeze({
+    COMMENTING:   "commenting",   // oa:commenting
+    TAGGING:      "tagging",      // oa:tagging
+    DESCRIBING:   "describing",   // oa:describing
+    IDENTIFYING:  "identifying",  // oa:identifying
+    CLASSIFYING:  "classifying"   // oa:classifying
+});
+
+/**
+ * Minimal valid Web Annotation template (frozen — do not mutate).
+ *
+ * Required fields per https://www.w3.org/TR/annotation-model/:
+ *   @context  — declares JSON-LD 1.1 Web Annotation vocabulary
+ *   type      — "Annotation" → oa:Annotation
+ *   body      — annotation content → oa:hasBody
+ *   target    — URI of the resource being annotated → oa:hasTarget
+ *
+ * Body properties with linked-data context definitions:
+ *   body.type     "TextualBody"  → oa:TextualBody
+ *   body.value    ""             → rdf:value  (http://www.w3.org/1999/02/22-rdf-syntax-ns#value)
+ *   body.format   "text/plain"   → dc:format  (http://purl.org/dc/elements/1.1/format)
+ *   body.language "en"           → dc:language (http://purl.org/dc/elements/1.1/language)
+ *   motivation    "commenting"   → oa:motivatedBy (http://www.w3.org/ns/oa#motivatedBy)
+ *
+ * The `id` field is assigned by RERUM after a successful CREATE call.
+ */
+export const MINIMAL_ANNOTATION_TEMPLATE = Object.freeze({
+    "@context": ANNOTATION_CONTEXT,
+    "type": "Annotation",
+    "motivation": MOTIVATIONS.COMMENTING,
+    "body": Object.freeze({
+        "type": "TextualBody",
+        "value": "",
+        "format": "text/plain",
+        "language": "en"
+    }),
+    "target": ""
+});
+
+/**
+ * Build a minimal valid JSON-LD 1.1 Web Annotation object.
+ *
+ * @param {string} bodyText   - Plain-text annotation content (required, non-empty)
+ * @param {string} targetUri  - URI of the resource being annotated (required, non-empty)
+ * @param {string} [motivation="commenting"] - oa:motivatedBy value; use MOTIVATIONS constants
+ * @param {string} [language="en"]           - BCP47 language tag for the body text
+ * @returns {Object} A new annotation object ready to POST to RERUM
+ * @throws {Error} if bodyText or targetUri is empty or not a string
+ */
+export function buildAnnotation(bodyText, targetUri, motivation = MOTIVATIONS.COMMENTING, language = "en") {
+    if (typeof bodyText !== "string" || !bodyText.trim()) {
+        throw new Error("bodyText must be a non-empty string.");
+    }
+    if (typeof targetUri !== "string" || !targetUri.trim()) {
+        throw new Error("targetUri must be a non-empty string.");
+    }
+    return {
+        "@context": ANNOTATION_CONTEXT,
+        "type": "Annotation",
+        "motivation": motivation,
+        "body": {
+            "type": "TextualBody",
+            "value": bodyText.trim(),
+            "format": "text/plain",
+            "language": language || "en"
+        },
+        "target": targetUri.trim()
+    };
+}

--- a/web/js/components/annotatorUI.js
+++ b/web/js/components/annotatorUI.js
@@ -1,0 +1,93 @@
+import { buildAnnotation, MOTIVATIONS, MINIMAL_ANNOTATION_TEMPLATE } from '../annotationTemplate.js';
+import { create } from '../services/objectService.js';
+import PLAYGROUND from '../config.js';
+
+const PREVIEW_ID = "annotation-preview";
+const STATUS_ID  = "annotator-status";
+const SAVE_BTN_ID = "annotator-save-btn";
+
+function getFields() {
+    return {
+        bodyText:   document.getElementById("annotator-body")?.value ?? "",
+        targetUri:  document.getElementById("annotator-target")?.value ?? "",
+        motivation: document.getElementById("annotator-motivation")?.value ?? MOTIVATIONS.COMMENTING,
+        language:   document.getElementById("annotator-language")?.value ?? "en"
+    };
+}
+
+function isFormValid({ bodyText, targetUri }) {
+    return bodyText.trim().length > 0 && targetUri.trim().length > 0;
+}
+
+function updatePreview() {
+    const previewEl = document.getElementById(PREVIEW_ID);
+    const saveBtn   = document.getElementById(SAVE_BTN_ID);
+    const { bodyText, targetUri, motivation, language } = getFields();
+
+    if (!previewEl) return;
+
+    if (!isFormValid({ bodyText, targetUri })) {
+        // Show the empty template when required fields are absent
+        previewEl.textContent = JSON.stringify(MINIMAL_ANNOTATION_TEMPLATE, null, 2);
+        if (saveBtn) saveBtn.disabled = true;
+        return;
+    }
+
+    try {
+        const annotation = buildAnnotation(bodyText, targetUri, motivation, language);
+        previewEl.textContent = JSON.stringify(annotation, null, 2);
+        if (saveBtn) saveBtn.disabled = false;
+    } catch {
+        if (saveBtn) saveBtn.disabled = true;
+    }
+}
+
+function setStatus(message, isError = false) {
+    const statusEl = document.getElementById(STATUS_ID);
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.className = isError ? "annotator-status annotator-status--error" : "annotator-status annotator-status--success";
+}
+
+async function handleSave() {
+    const saveBtn = document.getElementById(SAVE_BTN_ID);
+    const { bodyText, targetUri, motivation, language } = getFields();
+
+    if (!isFormValid({ bodyText, targetUri })) return;
+
+    saveBtn.disabled = true;
+    setStatus("Saving to RERUM…");
+
+    try {
+        const annotation = buildAnnotation(bodyText, targetUri, motivation, language);
+        const saved = await create(annotation);
+        const savedId = saved?.["@id"] ?? saved?.id ?? "";
+
+        setStatus(savedId
+            ? `Saved. RERUM URI: ${savedId}`
+            : "Saved to RERUM."
+        );
+
+        document.getElementById(PREVIEW_ID).textContent = JSON.stringify(saved, null, 2);
+
+        document.dispatchEvent(new CustomEvent(PLAYGROUND.EVENTS.CREATED, {
+            detail: { annotation: saved },
+            bubbles: true
+        }));
+    } catch (err) {
+        setStatus("Save failed: " + (err?.message ?? "Unknown error"), true);
+        saveBtn.disabled = false;
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    const inputs = ["annotator-body", "annotator-target", "annotator-motivation", "annotator-language"];
+    inputs.forEach(id => {
+        document.getElementById(id)?.addEventListener("input", updatePreview);
+    });
+
+    document.getElementById(SAVE_BTN_ID)?.addEventListener("click", handleSave);
+
+    // Initialize preview with the empty template
+    updatePreview();
+});

--- a/web/menu.html
+++ b/web/menu.html
@@ -4,4 +4,5 @@
     <a href="#">Contribute</a>
     <a href="#">Contact</a>
     <a href="tools.html">Tools</a>
+    <a href="annotator.html">Annotator</a>
 </div>


### PR DESCRIPTION
Defines the W3C Web Annotation JSON-LD 1.1 template and lays out the annotator module architecture.    
   
  Changes:                                                                                               
  - web/js/annotationTemplate.js — core deliverable: exports ANNOTATION_CONTEXT, MOTIVATIONS,
  MINIMAL_ANNOTATION_TEMPLATE, and buildAnnotation() with full linked-data context documentation for     
  every field                                                                                       
  - web/annotator.html + annotatorUI.js + annotator.css — page skeleton: two-panel form/preview UI that  
  builds a live JSON-LD preview and saves to RERUM                                                     
  - docs/docs/annotator.md — architecture diagram, required-fields table, and body property → linked-data
   URI mapping                                                                                           
  - web/menu.html — adds Annotator nav link                                                              
                                                                                                          
  Closes #141.